### PR TITLE
Windows line endings: Special handling for LF character

### DIFF
--- a/test/unit/EscposPrintBufferTest.php
+++ b/test/unit/EscposPrintBufferTest.php
@@ -179,4 +179,14 @@ class EscposPrintBufferTest extends PHPUnit_Framework_TestCase
         $this -> buffer -> writeText("Tiếng Việt, còn gọi tiếng Việt Nam hay Việt ngữ, là ngôn ngữ của người Việt (người Kinh) và là ngôn ngữ chính thức tại Việt Nam.\n");
         $this -> checkOutput("\x1b@Ti\x1bt\x1e\xd5ng Vi\xd6t, c\xdfn g\xe4i ti\xd5ng Vi\xd6t Nam hay Vi\xd6t ng\xf7, l\xb5 ng\xabn ng\xf7 c\xf1a ng\xad\xeai Vi\xd6t (ng\xad\xeai Kinh) v\xb5 l\xb5 ng\xabn ng\xf7 ch\xddnh th\xf8c t\xb9i Vi\xd6t Nam.\x0a");
     }
+
+    public function testWindowsLineEndings() {
+        $this -> buffer -> writeText("Hello World!\r\n");
+        $this -> checkOutput("\x1b@Hello World!\x0a");
+    }
+
+    public function testWindowsLineEndingsRaw() {
+        $this -> buffer -> writeTextRaw("Hello World!\r\n");
+        $this -> checkOutput("\x1b@Hello World!\x0a");
+    }
 }


### PR DESCRIPTION
Skip past LF ("\r") character rather than writing a question mark.

Previously, "\r\n" would cause "?\n" to appear in the output, but now "\r\n" is wound back
to "\n" on its own.

Reference:

- #209