### PR TITLE
Add coverage reporting to build process

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,4 @@
+service_name: travis-ci
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ doc/doxygen_sqlite3.db
 # composer files
 vendor/
 
+# other build files
+build/*
+*.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,14 @@ matrix:
 install:
   - composer install
 
+before_script:
+  - mkdir -p build/logs/
+
 script:
   - php vendor/bin/phpcs --standard=psr2 src/ -n
-  - php vendor/bin/phpunit --configuration test/phpunit.xml --coverage-text
+  - php vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+after_success:
+  - wget -c -nc https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
+  - php coveralls.phar -v
 ...

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build Status](https://travis-ci.org/mike42/escpos-php.svg?branch=master)](https://travis-ci.org/mike42/escpos-php) [![Latest Stable Version](https://poser.pugx.org/mike42/escpos-php/v/stable)](https://packagist.org/packages/mike42/escpos-php)
 [![Total Downloads](https://poser.pugx.org/mike42/escpos-php/downloads)](https://packagist.org/packages/mike42/escpos-php)
 [![License](https://poser.pugx.org/mike42/escpos-php/license)](https://packagist.org/packages/mike42/escpos-php)
+[![Coverage Status](https://coveralls.io/repos/github/mike42/escpos-php/badge.svg?branch=192-coverage)](https://coveralls.io/github/mike42/escpos-php?branch=192-coverage)
 
 This project implements a subset of Epson's ESC/POS protocol for thermal receipt printers. It allows you to generate and print receipts with basic formatting, cutting, and barcodes on a compatible printer.
 

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Fetch a copy of this code and load dependencies with composer:
 
 Execute unit tests via `phpunit`:
 
-    php vendor/bin/phpunit --configuration test/phpunit.xml --coverage-text
+    php vendor/bin/phpunit --coverage-text
 
 This project uses the PSR-2 standard, which can be checked via [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer):
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/mike42/escpos-php.svg?branch=master)](https://travis-ci.org/mike42/escpos-php) [![Latest Stable Version](https://poser.pugx.org/mike42/escpos-php/v/stable)](https://packagist.org/packages/mike42/escpos-php)
 [![Total Downloads](https://poser.pugx.org/mike42/escpos-php/downloads)](https://packagist.org/packages/mike42/escpos-php)
 [![License](https://poser.pugx.org/mike42/escpos-php/license)](https://packagist.org/packages/mike42/escpos-php)
-[![Coverage Status](https://coveralls.io/repos/github/mike42/escpos-php/badge.svg?branch=192-coverage)](https://coveralls.io/github/mike42/escpos-php?branch=192-coverage)
+[![Coverage Status](https://coveralls.io/repos/github/mike42/escpos-php/badge.svg?branch=development)](https://coveralls.io/github/mike42/escpos-php?branch=development)
 
 This project implements a subset of Epson's ESC/POS protocol for thermal receipt printers. It allows you to generate and print receipts with basic formatting, cutting, and barcodes on a compatible printer.
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="bootstrap.php"
+<phpunit bootstrap="test/bootstrap.php"
 timeoutForSmallTests="1"
 timeoutForMediumTests="10"
 timeoutForLargeTests="60"
@@ -7,15 +7,15 @@ strict="true"
 >
   <testsuites>
     <testsuite name="unit">
-      <directory>unit</directory>
+      <directory>test/unit</directory>
     </testsuite>
     <testsuite name="integration">
-      <directory>integration</directory>
+      <directory>test/integration</directory>
     </testsuite>
   </testsuites>
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">../src</directory>
+      <directory suffix=".php">src</directory>
     </whitelist>
   </filter>
 </phpunit>


### PR DESCRIPTION
This pull request introduces "Coverall" coverage reports to the build.

A coverage badge is displayed on the README, and the PHPUnit configuration has also moved.

Ref: 

- #192