### PR TITLE
Add link to ePOS-Device SDK for JavaScript in FAQ

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -105,6 +105,7 @@ Here are some browser-based printing tools which you may like to consider instea
 - Use system printing with a vendor driver, and some good `@media print` CSS
 - [Chrome Raw Print](https://github.com/receipt-print-hq/chrome-raw-print) app
 - [qz](https://qz.io/)
+- [ePOS-Device SDK for JavaScript](https://reference.epson-biz.com/modules/ref_epos_device_js_en/index.php?content_id=139). Requires network interface card that supports ePOS (UB-E04/R04)
 
 Please direct queries about client-side printing products to the appropriate project.
 


### PR DESCRIPTION
I've been forced recently to make the switch to from server side to client side printing and have found this SDK to be exactly what I needed. 

I've been using escpos-php for a while and it's **awesome**. It took me quite a while (and a lot of stress) to find a viable client side alternative so I wanted to share it with others that might be in the same situation.

Note: I'm not sure why github thinks I changed line 136, I only added line 108.