### PR TITLE
Update LICENSE.md for GitHub recognition

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,7 @@
-escpos-php: PHP receipt printer library for use with ESC/POS-compatible
-thermal and impact printers.
+MIT License
 
-Copyright (c) 2014-16 Michael Billington <michael.billington@gmail.com>,
-incorporating modifications by others. See CONTRIBUTORS.md for a full list.
+Copyright (c) 2014-2016 Michael Billington, incorporating modifications by others.
+See CONTRIBUTORS.md for a full list.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10,10 +9,10 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
- 
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
- 
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
White-space and header changes to license, to match GitHub template.

Currently, GitHub does not recognize that this is MIT license, hoping to fix.