### PR TITLE
New ApiPrintConnector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require": {
         "php": ">=5.3.9",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "guzzlehttp/guzzle": "^3.8"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
@@ -30,4 +31,3 @@
         }
     }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,162 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5c43a36988992decbc37e279e954fce2",
-    "content-hash": "7130afa0d442e6aa68643211165022da",
-    "packages": [],
+    "hash": "e145406516f5264b39ddb110ce8ff39c",
+    "content-hash": "fb7f368c7651c5d4efdbc73bd556f96e",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "v3.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
+                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": ">=2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "*",
+                "monolog/monolog": "1.*",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "1.0.*",
+                "symfony/class-loader": "*",
+                "zendframework/zend-cache": "<2.3",
+                "zendframework/zend-log": "<2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2014-01-28 22:29:15"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "74877977f90fb9c3e46378d5764217c55f32df34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/74877977f90fb9c3e46378d5764217c55f32df34",
+                "reference": "74877977f90fb9c3e46378d5764217c55f32df34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-01-02 20:30:24"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Mike42\Escpos\PrintConnectors;
+
+use Guzzle\Http\Client;
+use Guzzle\Http\Message\Request;
+use Guzzle\Http\Message\Response;
+use Exception;
+
+class ApiPrintConnector implements PrintConnector
+{
+    /**
+     * @var string
+     */
+    protected $stream;
+    /**
+     * @var Client
+     */
+    protected $httpClient;
+
+    /**
+     * @var string
+     */
+    protected $printerId;
+    /**
+     * @var string
+     */
+    protected $apiToken;
+
+    /**
+    * Construct new connector
+    *
+    * @param string $host
+    * @param string $printerId
+    * @param string $apiToken
+    */
+    public function __construct($host, $printerId, $apiToken)
+    {
+        $this->httpClient = new Client(['base_uri' => $host]);
+        $this->printerId = $printerId;
+        $this->apiToken = $apiToken;
+
+        $this->stream = '';
+    }
+
+    /**
+     * Print connectors should cause a NOTICE if they are deconstructed
+     * when they have not been finalized.
+     */
+    public function __destruct()
+    {
+        if (! empty($this->stream)) {
+            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+        }
+    }
+
+    /**
+     * Finish using this print connector (close file, socket, send
+     * accumulated output, etc).
+     */
+    public function finalize()
+    {
+        /** @var Request $request */
+        $request = $this->httpClient->post(
+            'printers/'.$this->printerId.'/print?api_token='.$this->apiToken,
+            null,
+            $this->stream
+        );
+
+        /** @var Response $response */
+        $response = $request->send();
+
+        if (! $response->isSuccessful()) {
+            throw new Exception(
+                sprintf('Failed to print. API returned "%s: %s"', $response->getStatusCode(), $response->getReasonPhrase())
+            );
+        }
+
+        $this->stream = '';
+    }
+
+    /**
+     * Read data from the printer.
+     *
+     * @param string $len Length of data to read.
+     * @return string Data read from the printer.
+     */
+    public function read($len)
+    {
+        return $this->stream;
+    }
+
+    /**
+     * Write data to the print connector.
+     *
+     * @param string $data The data to write
+     */
+    public function write($data)
+    {
+        $this->stream .= $data;
+    }
+}

--- a/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
@@ -36,7 +36,7 @@ class ApiPrintConnector implements PrintConnector
     */
     public function __construct($host, $printerId, $apiToken)
     {
-        $this->httpClient = new Client(['base_uri' => $host]);
+        $this->httpClient = new Client(array('base_uri' => $host));
         $this->printerId = $printerId;
         $this->apiToken = $apiToken;
 


### PR DESCRIPTION
This connector will send print jobs to this [print server API app](https://github.com/ablunier/escpos-print-api).

## Use cases

If your printer is in a different network than your webapp and you can't stand up a VPN, you can install this API in your printer's network and connect with it from your webapp with this new connector.