### PR TITLE
Allows PHP nightly to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ php:
 
 matrix:
   allow_failures:
-    - php:
-      - nightly
+    - php: nightly
 
 install:
   - composer install


### PR DESCRIPTION
Minor correction to Travis CI, as broken `phpunit` on PHP nightly is not passing as expected.

Issue reference:

- N/A

Before:

![2017-02-build2](https://cloud.githubusercontent.com/assets/2080552/22624001/eab259dc-ebc1-11e6-9d4a-1334e6818eca.png)

After:

![2017-02-build](https://cloud.githubusercontent.com/assets/2080552/22624000/e983a3d6-ebc1-11e6-8c6d-3874ee756b11.png)
