### PR TITLE
Relax "guzzlehttp/guzzle" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,15 @@
     },
     "require": {
         "php": ">=5.3.9",
-        "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^3.8"
+        "ext-mbstring": "*"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "Allows the use of the ApiConnector to send print jobs over HTTP."
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "guzzlehttp/guzzle": "~3.0|~4.0|~5.0|~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -95,7 +95,7 @@ class ImagickEscposImage extends EscposImage
             return parent::loadImageData($filename);
         }
     
-        $im = $im = $this -> getImageFromFile($filename);
+        $im = $this -> getImageFromFile($filename);
         $this -> readImageFromImagick($im);
     }
 


### PR DESCRIPTION
This is not required for most users, and had introduced a break in compatibility.

Issue reference:

- #300