### PR TITLE
Add timeout parameter to NetworkPrintConnector

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
@@ -24,11 +24,16 @@ class NetworkPrintConnector extends FilePrintConnector
      *
      * @param string $ip IP address or hostname to use.
      * @param string $port The port number to connect on.
+     * @param string $timeout The connection timeout, in seconds.
      * @throws Exception Where the socket cannot be opened.
      */
-    public function __construct($ip, $port = "9100")
+    public function __construct($ip, $port = "9100", $timeout = false)
     {
-        $this -> fp = @fsockopen($ip, $port, $errno, $errstr);
+        // Default to 60 if default_socket_timeout isn't defined in the ini
+        $defaultSocketTimeout = ini_get("default_socket_timeout") ?: 60;
+        $timeout = $timeout ?: $defaultSocketTimeout;
+
+        $this -> fp = @fsockopen($ip, $port, $errno, $errstr, $timeout);
         if ($this -> fp === false) {
             throw new Exception("Cannot initialise NetworkPrintConnector: " . $errstr);
         }


### PR DESCRIPTION
Default to ini_get(‘default_socket_timeout’) or 60 seconds
Closes #348