### PR TITLE
About REGEX_SMB constant

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -100,7 +100,7 @@ class WindowsPrintConnector implements PrintConnector
     /**
      * Valid smb:// URI containing hostname & printer with optional user & optional password only.
      */
-    const REGEX_SMB = "/^smb:\/\/([\s\d\w-]+(:[\s\d\w-]+)?@)?([\d\w-]+\.)*[\d\w-]+\/([\d\w-]+\/)?[\d\w-]+(\s[\d\w-]+)*$/";
+    const REGEX_SMB = "/^smb:\/\/([\s\d\w-]+(:[\s\d\w-+]+)?@)?([\d\w-]+\.)*[\d\w-]+\/([\d\w-]+\/)?[\d\w-]+(\s[\d\w-]+)*$/";
 
     /**
      * @param string $dest


### PR DESCRIPTION
Today I had a problem while using a password with the + character. The library was throwing the BadMethodCallException located at line 155. So, to avoid it I added the + character in the REGEX_SMB constant. This will allow the connector to work with passwords that have such symbol. It would be a good idea to allow more special characters on passwords. I guess a little research would be needed to know which ones should be allowed.