### PR TITLE
Release paper function for EPSON TM-U295

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Epson TM-T20
 - Epson TM-T70II
 - Epson TM-U220
+- Epson TM-U295 (requires `release()` to release slip).
 - Epson FX-890 (requires `feedForm()` to release paper).
 - Excelvan HOP-E58
 - Excelvan HOP-E200 
@@ -319,6 +320,9 @@ Parameters:
 
 ### feedForm()
 Some printers require a form feed to release the paper. On most printers, this command is only useful in page mode, which is not implemented in this driver.
+
+### release()
+Some slip printers require release command to release the paper.
 
 ### feedReverse($lines)
 Print and reverse feed n lines.

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -540,6 +540,14 @@ class Printer
     }
 
     /**
+     * Some slip printers require `ESC q` sequence to release the paper.
+     */
+    public function release()
+    {
+        $this -> connector -> write(self::ESC . chr(113));
+    }
+
+    /**
      * Print and reverse feed n lines.
      *
      * @param int $lines number of lines to feed. If not specified, 1 line will be fed.

--- a/test/unit/EscposTest.php
+++ b/test/unit/EscposTest.php
@@ -980,6 +980,13 @@ class EscposTest extends PHPUnit_Framework_TestCase
         $this -> checkOutput("\x1b@\x0c");
     }
 
+    /* Release */
+    public function testRelease()
+    {
+        $this -> printer -> release();
+        $this -> checkOutput("\x1b@\x1b\x71");
+    }
+
     /* Set text size  */
     public function testSetTextSizeNormal()
     {


### PR DESCRIPTION
EPSON TM-U295 slip printer requires a `ESC q` sequence to release the paper. It adds a simple command to make this available.

Related documentation from TM-U295 Documentation

![Related](http://i.imgur.com/uFd2Omn.png)