### PR TITLE
Disable HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
This pull request removes HHVM from the build, since it no longer works on the Travis CI Ubuntu Precise build used for the 1.x branch.

#396 
