### PR TITLE
Dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ require __DIR__ . '/vendor/mike42/escpos-php/autoload.php';
 To maintain compatibility with as many systems as possible, this driver has few
 hard dependencies:
 
-- PHP 5.3 or above
+- PHP 5.4 or above.
 - `mbstring` extension, since the driver accepts UTF-8 encoding.
 
 It is also suggested that you install either `imagick` or `gd`, so that you can
@@ -531,7 +531,7 @@ This code is MIT licensed, and you are encouraged to contribute any modification
 
 For development, it's suggested that you load `imagick`, `gd` and `Xdebug` PHP exensions, and install `composer`.
 
-The tests are executed on [Travis CI](https://travis-ci.org/mike42/escpos-php) over PHP 5.3, 5.4, 5.5, 5.7, 7, and HHVM. Earlier versions of PHP are not supported.
+The tests are executed on [Travis CI](https://travis-ci.org/mike42/escpos-php) over PHP 5.4, 5.5, 5.6, 7.0, 7.2 and 7.2. Earlier versions of PHP are not supported in current releases.
 
 Fetch a copy of this code and load dependencies with composer:
 
@@ -552,20 +552,3 @@ The developer docs are build with [doxygen](https://github.com/doxygen/doxygen).
     make -C doc clean && make -C doc
 
 Pull requests and bug reports welcome.
-
-<!-- ## Other versions
-TODO: Some notes about related OSS projects will go here.
-Some forks of this project have been developed by others for specific use cases. Improvements from the following projects have been incorporated into escpos-php:
-
-- [wdoyle/EpsonESCPOS-PHP](https://github.com/wdoyle/EpsonESCPOS-PHP)
-- [ronisaha/php-esc-pos](https://github.com/ronisaha/php-esc-pos)-->
-
-<!--
-TODO: A table of printer models vs programming guides available via the web would be good, but should go outside this README
-## Vendor documentation
-Epson notes that not all of its printers support all ESC/POS features, and includes a table in their documentation:
-
-* [FAQ about ESC/POS from Epson](http://content.epson.de/fileadmin/content/files/RSD/downloads/escpos.pdf)
-
-Note that many printers produced by other vendors use the same standard, and are compatible by varying degrees.
--->

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "config": {
         "platform": {
-            "php": "5.3.9"
+            "php": "5.4.0"
         }
     },
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.4.0",
         "ext-mbstring": "*"
     },
     "suggest": {
@@ -26,9 +26,9 @@
         "ext-gd": "Used for image printing if present."
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
-        "squizlabs/php_codesniffer": "2.*",
-        "guzzlehttp/guzzle": "~3.0|~4.0|~5.0|~6.0"
+        "phpunit/phpunit": "^4.8",
+        "squizlabs/php_codesniffer": "^3.2",
+        "guzzlehttp/guzzle": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f82cf379d65648780f0850a73ee82785",
-    "content-hash": "cb289372c4f0093b1fe9d3d78442cb3f",
+    "content-hash": "0094775b67f67bc65c1ff4aebb0fd065",
     "packages": [],
     "packages-dev": [
         {
@@ -60,70 +59,35 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "v3.8.1",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba"
+                "reference": "f9acb4761844317e626a32259205bec1f1bc60d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
-                "reference": "4de0618a01b34aa1c8c33a3f13f396dcd3882eba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f9acb4761844317e626a32259205bec1f1bc60d2",
+                "reference": "f9acb4761844317e626a32259205bec1f1bc60d2",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.3",
-                "symfony/event-dispatcher": ">=2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-error-response": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0",
+                "react/promise": "^2.2"
             },
             "require-dev": {
-                "doctrine/cache": "*",
-                "monolog/monolog": "1.*",
-                "phpunit/phpunit": "3.7.*",
-                "psr/log": "1.0.*",
-                "symfony/class-loader": "*",
-                "zendframework/zend-cache": "<2.3",
-                "zendframework/zend-log": "<2.3"
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.8-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Guzzle": "src/",
-                    "Guzzle\\Tests": "tests/"
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -135,10 +99,6 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
@@ -152,7 +112,108 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-01-28 22:29:15"
+            "time": "2018-01-15T07:18:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-20T03:37:09+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -201,7 +262,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -264,7 +325,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -326,7 +387,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -373,7 +434,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -414,7 +475,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -463,7 +524,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -512,20 +573,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.35",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -584,7 +645,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06 05:18:07"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -640,7 +701,53 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/62785ae604c8d69725d693eb370e1d67e94c4053",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2017-03-25T12:08:31+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -704,7 +811,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -756,7 +863,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -806,7 +913,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -873,7 +980,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -924,7 +1031,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -977,7 +1084,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1012,67 +1119,40 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1090,7 +1170,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01 22:17:45"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1150,7 +1230,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21 08:33:48"
+            "time": "2017-02-21T08:33:48+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1199,7 +1279,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-01 18:13:50"
+            "time": "2017-03-01T18:13:50+00:00"
         }
     ],
     "aliases": [],
@@ -1208,11 +1288,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.9",
+        "php": ">=5.4.0",
         "ext-mbstring": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.3.9"
+        "php": "5.4.0"
     }
 }

--- a/src/Mike42/Escpos/CapabilityProfile.php
+++ b/src/Mike42/Escpos/CapabilityProfile.php
@@ -126,7 +126,7 @@ class CapabilityProfile
         $this->fonts = $profileData['fonts'];
         $this->media = $profileData['media'];
         // More complex fields that are loaded into custom objects
-        $this->codePages = array();
+        $this->codePages = [];
         $this->codePageCacheKey = md5(json_encode($profileData['codePages']));
         foreach ($profileData['codePages'] as $k => $v) {
             $this->codePages[$k] = new CodePage($v, self::$encodings[$v]);
@@ -334,10 +334,10 @@ class CapabilityProfile
     protected static function suggestProfileName($profileName)
     {
         $suggestions = self::suggestNearest($profileName, array_keys(self::$profiles), 3);
-        $alwaysSuggest = array(
+        $alwaysSuggest = [
             'simple',
             'default'
-        );
+        ];
         foreach ($alwaysSuggest as $item) {
             if (array_search($item, $suggestions) === false) {
                 array_push($suggestions, $item);

--- a/src/Mike42/Escpos/EscposImage.php
+++ b/src/Mike42/Escpos/EscposImage.php
@@ -59,7 +59,7 @@ abstract class EscposImage
      * @var string $imgColumnData
      *  Cached column-format data to avoid re-computation
      */
-    private $imgColumnData = array();
+    private $imgColumnData = [];
     
     /**
      * @var array:string $imgRasterData
@@ -313,7 +313,7 @@ abstract class EscposImage
      */
     private function getColumnFormat($highDensity)
     {
-        $out = array();
+        $out = [];
         $i = 0;
         while (($line = $this -> getColumnFormatLine($i, $highDensity)) !== null) {
             $out[] = $line;
@@ -422,7 +422,7 @@ abstract class EscposImage
     public static function load(
         $filename,
         $allow_optimisations = true,
-        array $preferred = array('imagick', 'gd', 'native')
+        array $preferred = ['imagick', 'gd', 'native']
     ) {
         /* Fail early if file is not readble */
         if (!file_exists($filename) || !is_readable($filename)) {
@@ -444,7 +444,7 @@ abstract class EscposImage
                 }
                 return new \Mike42\Escpos\GdEscposImage($filename, $allow_optimisations);
             } elseif ($implemetnation === 'native') {
-                if (!in_array($ext, array('wbmp', 'pbm', 'bmp'))) {
+                if (!in_array($ext, ['wbmp', 'pbm', 'bmp'])) {
                     // Pure PHP is fastest way to generate raster output from wbmp and pbm formats.
                     continue;
                 }

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -217,9 +217,9 @@ class ImagickEscposImage extends EscposImage
             throw new Exception(__FUNCTION__ . " requires imagick extension.");
         }
         /*
-    	 * Load first page at very low density (resolution), to figure out what
-    	 * density to use to achieve $pageWidth
-    	 */
+         * Load first page at very low density (resolution), to figure out what
+         * density to use to achieve $pageWidth
+         */
         try {
             $image = new \Imagick();
             $testRes = 2; // Test resolution

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -113,7 +113,7 @@ class ImagickEscposImage extends EscposImage
         $imgWidth = $im->getimagewidth();
         if ($imgWidth == $lineHeight) {
             // Return glob of this panel
-            return array($this -> getRasterBlobFromImage($im));
+            return [$this -> getRasterBlobFromImage($im)];
         } elseif ($imgWidth > $lineHeight) {
             // Calculations
             $slicesLeft = ceil($imgWidth / $lineHeight / 2);
@@ -133,7 +133,7 @@ class ImagickEscposImage extends EscposImage
         } else {
             /* Image is smaller than full width */
             $im -> extentimage($lineHeight, $im -> getimageheight(), 0, 0);
-            return array($this -> getRasterBlobFromImage($im));
+            return [$this -> getRasterBlobFromImage($im)];
         }
     }
 
@@ -235,7 +235,7 @@ class ImagickEscposImage extends EscposImage
             $image -> readImage($pdfFile);
             $pages = $image -> getNumberImages();
             /* Convert images to Escpos objects */
-            $ret = array();
+            $ret = [];
             for ($i = 0; $i < $pages; $i++) {
                 $image -> setIteratorIndex($i);
                 $ep = new ImagickEscposImage();

--- a/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
@@ -198,11 +198,11 @@ class EscposPrintBuffer implements PrintBuffer
         }
 
         /* Generate conversion tables */
-        $encode = array();
-        $available = array();
+        $encode = [];
+        $available = [];
 
         foreach ($supportedCodePages as $num => $codePage) {
-            $encode[$num] = array();
+            $encode[$num] = [];
             if (!$codePage -> isEncodable()) {
                 continue;
             }
@@ -213,7 +213,7 @@ class EscposPrintBuffer implements PrintBuffer
                     continue;
                 }
                 if (!isset($available[$utf8])) {
-                    $available[$utf8] = array();
+                    $available[$utf8] = [];
                 }
                 $available[$utf8][$num] = true;
                 $encode[$num][$utf8] = chr($char);
@@ -221,7 +221,7 @@ class EscposPrintBuffer implements PrintBuffer
         }
         
         /* Use generated data */
-        $dataArray = array("available" => $available, "encode" => $encode, "key" => $cacheKey);
+        $dataArray = ["available" => $available, "encode" => $encode, "key" => $cacheKey];
         $this -> available = $dataArray["available"];
         $this -> encode = $dataArray["encode"];
         $cacheData = serialize($dataArray);

--- a/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/ApiPrintConnector.php
@@ -36,7 +36,7 @@ class ApiPrintConnector implements PrintConnector
     */
     public function __construct($host, $printerId, $apiToken)
     {
-        $this->httpClient = new Client(array('base_uri' => $host));
+        $this->httpClient = new Client(['base_uri' => $host]);
         $this->printerId = $printerId;
         $this->apiToken = $apiToken;
 

--- a/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
@@ -34,7 +34,7 @@ final class DummyPrintConnector implements PrintConnector
      */
     public function __construct()
     {
-        $this -> buffer = array();
+        $this -> buffer = [];
     }
 
     public function __destruct()

--- a/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
@@ -55,8 +55,8 @@ class FilePrintConnector implements PrintConnector
     }
     
     /* (non-PHPdoc)
-	 * @see PrintConnector::read()
-	 */
+     * @see PrintConnector::read()
+     */
     public function read($len)
     {
         return fread($this -> fp, $len);

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -314,8 +314,8 @@ class WindowsPrintConnector implements PrintConnector
     }
     
     /* (non-PHPdoc)
-	 * @see PrintConnector::read()
-	 */
+     * @see PrintConnector::read()
+     */
     public function read($len)
     {
         /* Two-way communication is not supported */

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -155,7 +155,7 @@ class WindowsPrintConnector implements PrintConnector
             throw new BadMethodCallException("Printer '" . $dest . "' is not a valid " .
                 "printer name. Use local port (LPT1, COM1, etc) or smb://computer/printer notation.");
         }
-        $this -> buffer = array();
+        $this -> buffer = [];
     }
 
     public function __destruct()
@@ -333,11 +333,11 @@ class WindowsPrintConnector implements PrintConnector
      */
     protected function runCommand($command, &$outputStr, &$errorStr, $inputStr = null)
     {
-        $descriptors = array(
-                0 => array("pipe", "r"),
-                1 => array("pipe", "w"),
-                2 => array("pipe", "w"),
-        );
+        $descriptors = [
+                0 => ["pipe", "r"],
+                1 => ["pipe", "w"],
+                2 => ["pipe", "w"],
+        ];
         $process = proc_open($command, $descriptors, $fd);
         if (is_resource($process)) {
             /* Write to input */

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -399,7 +399,7 @@ class Printer
                 self::validateStringRegex($content, __FUNCTION__, "/^[0-9]{11,12}$/", "UPCA barcode content");
                 break;
             case self::BARCODE_UPCE:
-                self::validateIntegerMulti($len, array(array(6, 8), array(11, 12)), __FUNCTION__, "UPCE barcode content length");
+                self::validateIntegerMulti($len, [[6, 8], [11, 12]], __FUNCTION__, "UPCE barcode content length");
                 self::validateStringRegex($content, __FUNCTION__, "/^([0-9]{6,8}|[0-9]{11,12})$/", "UPCE barcode content");
                 break;
             case self::BARCODE_JAN13:
@@ -458,7 +458,7 @@ class Printer
     {
         self::validateInteger($size, 0, 3, __FUNCTION__);
         $rasterData = $img -> toRasterFormat();
-        $header = Printer::dataHeader(array($img -> getWidthBytes(), $img -> getHeight()), true);
+        $header = Printer::dataHeader([$img -> getWidthBytes(), $img -> getHeight()], true);
         $this -> connector -> write(self::GS . "v0" . chr($size) . $header);
         $this -> connector -> write($rasterData);
     }
@@ -484,7 +484,7 @@ class Printer
         // Header and density code (0, 1, 32, 33) re-used for every line
         $densityCode = ($highDensityHorizontal ? 1 : 0) + ($highDensityVertical ? 32 : 0);
         $colFormatData = $img -> toColumnFormat($highDensityVertical);
-        $header = Printer::dataHeader(array($img -> getWidth()), true);
+        $header = Printer::dataHeader([$img -> getWidth()], true);
         foreach ($colFormatData as $line) {
             // Print each line, double density etc for printing are set here also
             $this -> connector -> write(self::ESC . "*" . chr($densityCode) . $header . $line);
@@ -613,7 +613,7 @@ class Printer
     {
         self::validateInteger($size, 0, 3, __FUNCTION__);
         $rasterData = $img -> toRasterFormat();
-        $imgHeader = Printer::dataHeader(array($img -> getWidth(), $img -> getHeight()), true);
+        $imgHeader = Printer::dataHeader([$img -> getWidth(), $img -> getHeight()], true);
         $tone = '0';
         $colors = '1';
         $xm = (($size & self::IMG_DOUBLE_WIDTH) == Printer::IMG_DOUBLE_WIDTH) ? chr(2) : chr(1);
@@ -1061,7 +1061,7 @@ class Printer
      */
     protected static function dataHeader(array $inputs, $long = true)
     {
-        $outp = array();
+        $outp = [];
         foreach ($inputs as $input) {
             if ($long) {
                 $outp[] = Printer::intLowHigh($input, 2);
@@ -1135,7 +1135,7 @@ class Printer
      */
     protected static function validateInteger($test, $min, $max, $source, $argument = "Argument")
     {
-        self::validateIntegerMulti($test, array(array($min, $max)), $source, $argument);
+        self::validateIntegerMulti($test, [[$min, $max]], $source, $argument);
     }
     
     /**


### PR DESCRIPTION
This pull requests bumps the minimum required PHP version to 5.4.0, and updates documentation and dependencies accordingly.

PHP 5.3 users either upgrade their PHP, or run the 1.x branch of escpos-php. To ensure that we don't carry any PHP 5.3 users into this version, `composer.json` has been updated with the new minimum, and the `array()` syntax has intentionally been replaced with `[]`, which will only work on PHP 5.4 and above.

Reference:

- #530