### PR TITLE
Set SMB2 as default highest allowed protocol (Updated)

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -193,7 +193,7 @@ class WindowsPrintConnector implements PrintConnector
             if ($this -> userPassword == null) {
                 // No password
                 $command = sprintf(
-                    "smbclient %s -U %s -c %s -N",
+                    "smbclient %s -U %s -c %s -N -m SMB2",
                     escapeshellarg($device),
                     escapeshellarg($user),
                     escapeshellarg("print -")
@@ -202,14 +202,14 @@ class WindowsPrintConnector implements PrintConnector
             } else {
                 // With password
                 $command = sprintf(
-                    "smbclient %s %s -U %s -c %s",
+                    "smbclient %s %s -U %s -c %s -m SMB2",
                     escapeshellarg($device),
                     escapeshellarg($this -> userPassword),
                     escapeshellarg($user),
                     escapeshellarg("print -")
                 );
                 $redactedCommand = sprintf(
-                    "smbclient %s %s -U %s -c %s",
+                    "smbclient %s %s -U %s -c %s -m SMB2",
                     escapeshellarg($device),
                     escapeshellarg("*****"),
                     escapeshellarg($user),
@@ -219,7 +219,7 @@ class WindowsPrintConnector implements PrintConnector
         } else {
             // No authentication information at all
             $command = sprintf(
-                "smbclient %s -c %s -N",
+                "smbclient %s -c %s -N -m SMB2",
                 escapeshellarg($device),
                 escapeshellarg("print -")
             );
@@ -242,7 +242,7 @@ class WindowsPrintConnector implements PrintConnector
     {
         throw new Exception("Mac printing not implemented.");
     }
-    
+
     /**
      * Send data to printer -- platform-specific Windows code.
      *
@@ -298,7 +298,7 @@ class WindowsPrintConnector implements PrintConnector
             }
         }
     }
-    
+
     /**
      * @return string Current platform. Separated out for testing purposes.
      */
@@ -312,7 +312,7 @@ class WindowsPrintConnector implements PrintConnector
         }
         return self::PLATFORM_LINUX;
     }
-    
+
     /* (non-PHPdoc)
 	 * @see PrintConnector::read()
 	 */
@@ -321,7 +321,7 @@ class WindowsPrintConnector implements PrintConnector
         /* Two-way communication is not supported */
         return false;
     }
-    
+
     /**
      * Run a command, pass it data, and retrieve its return value, standard output, and standard error.
      *
@@ -359,7 +359,7 @@ class WindowsPrintConnector implements PrintConnector
             return -1;
         }
     }
-    
+
     /**
      * Copy a file. Separated out so that nothing is actually printed during test runs.
      *
@@ -371,7 +371,7 @@ class WindowsPrintConnector implements PrintConnector
     {
         return copy($from, $to);
     }
-    
+
     /**
      * Write data to a file. Separated out so that nothing is actually printed during test runs.
      *

--- a/test/unit/WindowsPrintConnectorTest.php
+++ b/test/unit/WindowsPrintConnectorTest.php
@@ -176,7 +176,7 @@ class WindowsPrintConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this -> getMockConnector("smb://example-pc/Printer", WindowsPrintConnector::PLATFORM_LINUX);
         $connector -> expects($this -> once())
                 -> method('runCommand')
-                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -c \'print -\' -N'));
+                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -c \'print -\' -N -m SMB2'));
         $connector -> expects($this -> exactly(0))
                 -> method('runCopy');
         $connector -> expects($this -> exactly(0))
@@ -189,7 +189,7 @@ class WindowsPrintConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this -> getMockConnector("smb://bob@example-pc/Printer", WindowsPrintConnector::PLATFORM_LINUX);
         $connector -> expects($this -> once())
                 -> method('runCommand')
-                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -U \'bob\' -c \'print -\' -N'));
+                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -U \'bob\' -c \'print -\' -N -m SMB2'));
         $connector -> expects($this -> exactly(0))
                 -> method('runCopy');
         $connector -> expects($this -> exactly(0))
@@ -202,7 +202,7 @@ class WindowsPrintConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this -> getMockConnector("smb://bob@example-pc/home/Printer", WindowsPrintConnector::PLATFORM_LINUX);
         $connector -> expects($this -> once())
                 -> method('runCommand')
-                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -U \'home\\bob\' -c \'print -\' -N'));
+                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' -U \'home\\bob\' -c \'print -\' -N -m SMB2'));
         $connector -> expects($this -> exactly(0))
                 -> method('runCopy');
         $connector -> expects($this -> exactly(0))
@@ -215,7 +215,7 @@ class WindowsPrintConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this -> getMockConnector("smb://bob:secret@example-pc/Printer", WindowsPrintConnector::PLATFORM_LINUX);
         $connector -> expects($this -> once())
                 -> method('runCommand')
-                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' \'secret\' -U \'bob\' -c \'print -\''));
+                -> with($this -> equalTo('smbclient \'//example-pc/Printer\' \'secret\' -U \'bob\' -c \'print -\' -m SMB2'));
         $connector -> expects($this -> exactly(0))
                 -> method('runCopy');
         $connector -> expects($this -> exactly(0))


### PR DESCRIPTION
Updates #488, which could not be merged due to build system issues.