### PR TITLE
Update printer list & sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,30 +67,35 @@ This driver is known to work with the following OS/interface combinations:
 ### Printers
 Many thermal receipt printers support ESC/POS to some degree. This driver has been known to work with:
 
+- 3nStrat POS-08
 - AURES ODP-333
 - AURES ODP-500
+- Bematech-4200-TH
 - Bixolon SRP-350III
+- Black Copper BC-85AC
 - Citizen CBM1000-II
 - Citizen CT-S310II
+- Dapper-Geyi Q583P 
 - Daruma DR800
 - EPOS TEP 220M
+- Epson EU-T332C
+- Epson FX-890 (requires `feedForm()` to release paper).
+- Epson TM-T20
+- Epson TM-T20II
+- Epson TM-T70
+- Epson TM-T70II
+- Epson TM-T81
+- Epson TM-T82II
 - Epson TM-T88II
 - Epson TM-T88III
 - Epson TM-T88IV
 - Epson TM-T88V
-- Epson TM-T70
-- Epson TM-T82II
-- Epson TM-T20
-- Epson TM-T20II
-- Epson TM-T70II
-- Epson TM-T81
 - Epson TM-U220
 - Epson TM-U295 (requires `release()` to release slip).
 - Epson TM-U590 and TM-U590P
-- Epson FX-890 (requires `feedForm()` to release paper).
 - Equal (EQ-IT-001) POS-58
-- Excelvan HOP-E58
 - Excelvan HOP-E200 
+- Excelvan HOP-E58
 - Excelvan HOP-E801
 - Excelvan ZJ-8220
 - Gainscha GP-5890x (Also marketed as EC Line 5890x)
@@ -100,28 +105,34 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Metapace T-1
 - Metapace T-25
 - Nexa PX700
+- Nyear NP100
 - Okipos 80 Plus III
 - Orient BTP-R580
 - P-822D
 - P85A-401 (make unknown)
 - Rongta RP326US
 - Rongta RP58-U
+- Senor TP-100
 - SEYPOS PRP-300 (Also marketed as TYSSO PRP-300)
+- Sicar POS-80
 - Silicon SP-201 / RP80USE
+- SPRT SP-POS88V
+- Star BSC10
 - Star TSP100 ECO
 - Star TSP100III FuturePRNT
 - Star TSP-650
 - Star TUP-592
-- SPRT SP-POS88V
+- Venus V248T
 - Xprinter F-900
+- Xprinter XP-58 Series
+- Xprinter XP-80C
+- Xprinter XP-90
 - XPrinter XP-Q20011
 - Xprinter XP-Q800
-- Xprinter XP-80C
-- Venus V248T
 - Zjiang NT-58H
 - Zjiang ZJ-5870
-- Zjiang ZJ-5890T (Marketed as POS 5890T)
 - Zjiang ZJ-5890K
+- Zjiang ZJ-5890T (Marketed as POS 5890T)
 
 If you use any other printer with this code, please [let us know](https://github.com/mike42/escpos-php/issues/new) so that it can be added to the list.
 


### PR DESCRIPTION
This pull request collects updates to the list of printers that have been reported to work by the user-base:

- Senor TP-100 #528
- 3nStrat POS-08  #527
- Black Copper BC-85AC #517
- Nyear NP100 #499
- Star BSC10 #487
- Sicar POS-80 #483
- Bematech-4200-TH #472
- Xprinter XP-90, XP-58 Series #463
- Dapper-Geyi Q583P #296 
- Epson EU-T332C #276