### PR TITLE
Include HHVM 3.21 LTS compatiboility for 2.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 before_script:
   # Install 'imagick' plugin
-  - printf "\n" | pecl install imagick
+  - bash -c 'if [[ $TRAVIS_PHP_VERSION != hhvm* ]]; then printf "\n" | pecl install imagick; fi'
   # Directory for coverage report
   - mkdir -p build/logs/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ php:
   - 7.1
   - 7.2
   - nightly
+  - hhvm-3.21
+  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm-nightly
 
 before_install:
   - sudo apt-get -qq update

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ This code is MIT licensed, and you are encouraged to contribute any modification
 
 For development, it's suggested that you load `imagick`, `gd` and `Xdebug` PHP exensions, and install `composer`.
 
-The tests are executed on [Travis CI](https://travis-ci.org/mike42/escpos-php) over PHP 5.4, 5.5, 5.6, 7.0, 7.2 and 7.2. Earlier versions of PHP are not supported in current releases.
+The tests are executed on [Travis CI](https://travis-ci.org/mike42/escpos-php) over PHP 5.4, 5.5, 5.6, 7.0, 7.1 and 7.2, plus the latest LTS version of HHVM, 3.21. Older versions of PHP are not supported in current releases.
 
 Fetch a copy of this code and load dependencies with composer:
 


### PR DESCRIPTION
As in title.

We previously tested on whichever version were available, but these were broken on Travis CI at some point.

Ref:
- #530 
- #396