### PR TITLE
Implement upside-down print command

### DIFF
--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -972,7 +972,18 @@ class Printer
         self::validateInteger($underline, 0, 2, __FUNCTION__);
         $this -> connector -> write(self::ESC . "-" . chr($underline));
     }
-    
+
+    /**
+     * Print each line upside-down (180 degrees rotated).
+     *
+     * @param boolean $on True to enable, false to disable.
+     */
+    public function setUpsideDown($on = true)
+    {
+        self::validateBoolean($on, __FUNCTION__);
+        $this -> connector -> write(self::ESC . "{" . ($on ? chr(1) : chr(0)));
+    }
+
     /**
      * Add text to the buffer.
      *

--- a/test/unit/EscposTest.php
+++ b/test/unit/EscposTest.php
@@ -1100,6 +1100,13 @@ class EscposTest extends PHPUnit_Framework_TestCase
         $this -> printer -> setPrintLeftMargin(70000);
         $this -> checkOutput();
     }
+
+    /* Upside-down print */
+    public function testSetUpsideDown()
+    {
+        $this -> printer -> setUpsideDown(true);
+        $this -> checkOutput("\x1b@\x1b{\x01");
+    }
 }
 
 /*


### PR DESCRIPTION
Example snippet:

```php
<?php
/* Demonstration of upside-down printing */
require __DIR__ . '/vendor/autoload.php';
use Mike42\Escpos\Printer;
use Mike42\Escpos\PrintConnectors\FilePrintConnector;

$connector = new FilePrintConnector("/dev/usb/lp0");
$printer = new Printer($connector);

// Most simple example
$printer -> text("Hello\n");
$printer -> setUpsideDown(true);
$printer -> text("World\n");
$printer -> cut();
$printer -> close();
```

Prints:

![615-example](https://user-images.githubusercontent.com/2080552/47493344-c961e780-d89a-11e8-955f-d43d65ca8c64.jpg)

Reference:

- #615 