### PR TITLE
Changes for release 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ This driver is known to work with the following OS/interface combinations:
 ### Printers
 Many thermal receipt printers support ESC/POS to some degree. This driver has been known to work with:
 
-- 3nStrat POS-08
+- 3nStar RPT-008
+- Approx APPPOS80AM
 - AURES ODP-333
 - AURES ODP-500
 - Bematech-4200-TH
 - Bematech LR2000E
+- Birch PRP-085III
 - Bixolon SRP-350III
 - Black Copper BC-85AC
 - Citizen CBM1000-II
@@ -99,23 +101,29 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Excelvan HOP-E200 
 - Excelvan HOP-E58
 - Excelvan HOP-E801
-- Excelvan ZJ-8220
 - Gainscha GP-5890x (Also marketed as EC Line 5890x)
 - Gainscha GP-U80300I (Also marketed as gprinter GP-U80300I)
 - gprinter GP-U80160I
+- HOIN HOP-H58
+- Ithaca iTherm 28
 - Hasar HTP 250
 - Metapace T-1
 - Metapace T-25
 - Nexa PX700
 - Nyear NP100
-- Okipos 80 Plus III
+- OKI RT322
+- OKI 80 Plus III
 - Orient BTP-R580
-- Partner Tech RP320
 - P-822D
 - P85A-401 (make unknown)
+- Partner Tech RP320
+- POSLIGNE ODP200H-III-G
+- QPOS Q58M
 - Rongta RP326US
 - Rongta RP58-U
+- Rongta RP80USE
 - Senor TP-100
+- Sewoo SLK-TS400
 - SEYPOS PRP-300 (Also marketed as TYSSO PRP-300)
 - Sicar POS-80
 - Silicon SP-201 / RP80USE
@@ -126,6 +134,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Star TSP-650
 - Star TUP-592
 - Venus V248T
+- Xeumior SM-8330
 - Xprinter F-900
 - Xprinter XP-365B
 - Xprinter XP-58 Series
@@ -135,9 +144,8 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Xprinter XP-Q800
 - Zjiang NT-58H
 - Zjiang ZJ-5870
-- Zjiang ZJ-5890K
-- Zjiang ZJ-5890T (Marketed as POS 5890T)
-- Zjiang ZJ-8220
+- Zjiang ZJ-5890 (Also sold as POS-5890 by many vendors; ZJ-5890K, ZJ-5890T also work).
+- Zjiang ZJ-8220 (Also marketed as Excelvan ZJ-8220)
 
 If you use any other printer with this code, please [let us know](https://github.com/mike42/escpos-php/issues/new) so that it can be added to the list.
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - AURES ODP-333
 - AURES ODP-500
 - Bematech-4200-TH
+- Bematech LR2000E
 - Bixolon SRP-350III
 - Black Copper BC-85AC
 - Citizen CBM1000-II
 - Citizen CT-S310II
 - Dapper-Geyi Q583P 
 - Daruma DR800
+- DR-MP200 (manufacturer unknown)
 - EPOS TEP 220M
 - Epson EU-T332C
 - Epson FX-890 (requires `feedForm()` to release paper).
@@ -108,6 +110,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Nyear NP100
 - Okipos 80 Plus III
 - Orient BTP-R580
+- Partner Tech RP320
 - P-822D
 - P85A-401 (make unknown)
 - Rongta RP326US
@@ -124,6 +127,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Star TUP-592
 - Venus V248T
 - Xprinter F-900
+- Xprinter XP-365B
 - Xprinter XP-58 Series
 - Xprinter XP-80C
 - Xprinter XP-90
@@ -133,6 +137,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Zjiang ZJ-5870
 - Zjiang ZJ-5890K
 - Zjiang ZJ-5890T (Marketed as POS 5890T)
+- Zjiang ZJ-8220
 
 If you use any other printer with this code, please [let us know](https://github.com/mike42/escpos-php/issues/new) so that it can be added to the list.
 

--- a/example/character-encodings-with-images.php
+++ b/example/character-encodings-with-images.php
@@ -3,9 +3,9 @@
 require __DIR__ . '/../autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
 use Mike42\Escpos\PrintBuffers\EscposPrintBuffer;
 use Mike42\Escpos\PrintBuffers\ImagePrintBuffer;
+use Mike42\Escpos\CapabilityProfile;
 
 /**
  * This example builds on character-encodings.php, also providing an image-based rendering.
@@ -21,7 +21,7 @@ include(dirname(__FILE__) . '/resources/character-encoding-test-strings.inc');
 try {
     // Enter connector and capability profile
     $connector = new FilePrintConnector("php://stdout");
-    $profile = DefaultCapabilityProfile::getInstance();
+    $profile = CapabilityProfile::load('default');
     $buffers = array(new EscposPrintBuffer(), new ImagePrintBuffer());
 
     /* Print a series of receipts containing i18n example strings */

--- a/example/character-encodings.php
+++ b/example/character-encodings.php
@@ -3,7 +3,7 @@
 require __DIR__ . '/../autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
+use Mike42\Escpos\CapabilityProfile;
 
 /**
  * This demonstrates available character encodings. Escpos-php accepts UTF-8,
@@ -27,7 +27,7 @@ include(dirname(__FILE__) . '/resources/character-encoding-test-strings.inc');
 try {
     // Enter connector and capability profile (to match your printer)
     $connector = new FilePrintConnector("php://stdout");
-    $profile = DefaultCapabilityProfile::getInstance();
+    $profile = CapabilityProfile::load("default");
     
     /* Print a series of receipts containing i18n example strings */
     $printer = new Printer($connector, $profile);

--- a/example/character-tables.php
+++ b/example/character-tables.php
@@ -17,11 +17,11 @@
 require __DIR__ . '/../autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
+use Mike42\Escpos\CapabilityProfile;
 
 // Enter connector and capability profile (to match your printer)
 $connector = new FilePrintConnector("php://stdout");
-$profile = DefaultCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("default");
 $verbose = false; // Skip tables which iconv wont convert to (ie, only print characters available with UTF-8 input)
 
 /* Print a series of receipts containing i18n example strings - Code below shouldn't need changing */

--- a/example/specific/32-german-tm-t20-ii-custom-command.php
+++ b/example/specific/32-german-tm-t20-ii-custom-command.php
@@ -1,8 +1,8 @@
 <?php
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
 
 /*
  * This example shows how tok send a custom command to the printer-
@@ -22,7 +22,7 @@ use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
 
 /* Set up profile & connector */
 $connector = new FilePrintConnector("php://output");
-$profile = DefaultCapabilityProfile::getInstance(); // Works for Epson printers
+$profile = CapabilityProfile::load("default"); // Works for Epson printers
 
 $printer = new Printer($connector, $profile);
 $cmd = Printer::ESC . "V" . chr(1); // Try out 90-degree rotation.

--- a/example/specific/33-spanish-seypos-prp-300.php
+++ b/example/specific/33-spanish-seypos-prp-300.php
@@ -7,12 +7,12 @@
  * Use the hardware switch to activate "Two-byte Character Code"
  */
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\SimpleCapabilityProfile;
 
 $connector = new FilePrintConnector("php://output");
-$profile = SimpleCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("simple"); // Works for Epson printers
 $printer = new Printer($connector);
 $printer -> text("El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.\n");
 $printer -> cut();

--- a/example/specific/37-chinese.php
+++ b/example/specific/37-chinese.php
@@ -7,12 +7,12 @@
  * can be properly detected and printed alongside other encodings.
  */
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\SimpleCapabilityProfile;
 
 $connector = new FilePrintConnector("/dev/usb/lp1");
-$profile = SimpleCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("default");
 
 $printer = new Printer($connector);
 

--- a/example/specific/39-currency-symbols.php
+++ b/example/specific/39-currency-symbols.php
@@ -1,12 +1,11 @@
 <?php
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 use Mike42\Escpos\PrintBuffers\ImagePrintBuffer;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
-use Mike42\Escpos\CapabilityProfiles\SimpleCapabilityProfile;
 
-$profile = DefaultCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("default");
 // This is a quick demo of currency symbol issues in #39.
 
 /* Option 1: Native ESC/POS characters, depends on printer and is buggy. */
@@ -40,7 +39,7 @@ $printer -> close();
  are not available in CP437. CP858 has good printer support, but is not
  included in all iconv builds.
 */
-class CustomCapabilityProfile extends SimpleCapabilityProfile
+class CustomCapabilityProfile extends CapabilityProfile
 {
     function getCustomCodePages()
     {

--- a/example/specific/44-pound-symbol-star-tsp650.php
+++ b/example/specific/44-pound-symbol-star-tsp650.php
@@ -8,14 +8,14 @@
 
 // Adjust these to your environment
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\SimpleCapabilityProfile;
 
 $connector = new FilePrintConnector("php://stdout");
 
 // Start printer
-$profile = SimpleCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("simple");
 $printer = new Printer($connector, $profile);
 
 // A) Raw pound symbol

--- a/example/specific/50-P-822D-greek.php
+++ b/example/specific/50-P-822D-greek.php
@@ -1,13 +1,13 @@
 <?php
 /* Example of Greek text on the P-822D */
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
-use Mike42\Escpos\CapabilityProfiles\P822DCapabilityProfile;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 
 // Setup the printer
 $connector = new FilePrintConnector("php://stdout");
-$profile = P822DCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("P822D");
 $printer = new Printer($connector, $profile);
 
 // Print a Greek pangram

--- a/example/specific/54-gfx-sidebyside.php
+++ b/example/specific/54-gfx-sidebyside.php
@@ -12,9 +12,9 @@
  * object into some sort of cache if you will re-use the output.
  */
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\EscposImage;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 
 // Paths to images to combine
@@ -38,11 +38,11 @@ try {
         // Detect and handle command failure
         throw new Exception("Command \"$cmd\" returned $retval." . implode("\n", $outp));
     }
-    $img = new EscposImage($imgCombined_path);
+    $img = EscposImage::load($imgCombined_path);
 
     // Setup the printer
     $connector = new FilePrintConnector("php://stdout");
-    $profile = DefaultCapabilityProfile::getInstance();
+    $profile = CapabilityProfile::load("default");
 
     // Run the actual print
     $printer = new Printer($connector, $profile);

--- a/example/specific/6-arabic-epos-tep-220m.php
+++ b/example/specific/6-arabic-epos-tep-220m.php
@@ -14,10 +14,10 @@
  *      handling the layout for this example.
  */
 require __DIR__ . '/../../autoload.php';
+use Mike42\Escpos\CapabilityProfile;
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 use Mike42\Escpos\PrintBuffers\ImagePrintBuffer;
-use Mike42\Escpos\CapabilityProfiles\EposTepCapabilityProfile;
 
 /*
  * Drop Ar-php into the folder listed below:
@@ -55,7 +55,7 @@ $buffer = new ImagePrintBuffer();
 $buffer -> setFont($fontPath);
 $buffer -> setFontSize($fontSize);
 
-$profile = EposTepCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("TEP-200M");
 $connector = new FilePrintConnector("php://output");
         // = new WindowsPrintConnector("LPT2");
         // Windows LPT2 was used in the bug tracker

--- a/example/specific/62-greek-symbol-swap.php
+++ b/example/specific/62-greek-symbol-swap.php
@@ -2,10 +2,10 @@
 require __DIR__ . '/../../autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
-use Mike42\Escpos\CapabilityProfiles\DefaultCapabilityProfile;
+use Mike42\Escpos\CapabilityProfile;
 
 $connector = new FilePrintConnector("php://stdout");
-$profile = DefaultCapabilityProfile::getInstance();
+$profile = CapabilityProfile::load("default");
 $printer = new Printer($connector, $profile);
 
 $printer -> text("Μιχάλης Νίκος\n");

--- a/example/specific/68-redblack.php
+++ b/example/specific/68-redblack.php
@@ -10,9 +10,9 @@ $connector = new FilePrintConnector("/dev/usb/lp0");
 $printer = new Printer($connector);
 try {
     $printer -> text("Hello World!\n");
-    $printer -> setColor(Escpos::COLOR_2);
+    $printer -> setColor(Printer::COLOR_2);
     $printer -> text("Red?!\n");
-    $printer -> setColor(Escpos::COLOR_1);
+    $printer -> setColor(Printer::COLOR_1);
     $printer -> text("Default color again?!\n");
     $printer -> cut();
 } finally {

--- a/src/Mike42/Escpos/CapabilityProfile.php
+++ b/src/Mike42/Escpos/CapabilityProfile.php
@@ -3,15 +3,15 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md
  * for details.
  */
+
 namespace Mike42\Escpos;
 
-use Mike42\Escpos\CodePage;
 use \InvalidArgumentException;
 
 /**
@@ -108,7 +108,7 @@ class CapabilityProfile
      * Construct new CapabilityProfile.
      * The encoding data must be loaded from disk before calling.
      *
-     * @param unknown $profileId
+     * @param string $profileId
      *            ID of the profile
      * @param array $profileData
      *            Profile data from disk.

--- a/src/Mike42/Escpos/CodePage.php
+++ b/src/Mike42/Escpos/CodePage.php
@@ -3,12 +3,13 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md
  * for details.
  */
+
 namespace Mike42\Escpos;
 
 use \InvalidArgumentException;

--- a/src/Mike42/Escpos/Devices/AuresCustomerDisplay.php
+++ b/src/Mike42/Escpos/Devices/AuresCustomerDisplay.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * This file is part of escpos-php: PHP receipt printer library for use with
+ * ESC/POS-compatible thermal and impact printers.
+ *
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
+ * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
+ *
+ * This software is distributed under the terms of the MIT license. See LICENSE.md
+ * for details.
+ */
+
 namespace Mike42\Escpos\Devices;
 
 use Mike42\Escpos\Printer;

--- a/src/Mike42/Escpos/GdEscposImage.php
+++ b/src/Mike42/Escpos/GdEscposImage.php
@@ -23,7 +23,7 @@ class GdEscposImage extends EscposImage
     /**
      * Load an image from disk, into memory, using GD.
      *
-     * @param string $filename The filename to load from
+     * @param string|null $filename The filename to load from
      * @throws Exception if the image format is not supported,
      *  or the file cannot be opened.
      */

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -3,12 +3,13 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md
  * for details.
  */
+
 namespace Mike42\Escpos;
 
 use Exception;
@@ -84,7 +85,7 @@ class ImagickEscposImage extends EscposImage
     /**
      * Load an image from disk, into memory, using Imagick.
      *
-     * @param string $filename The filename to load from
+     * @param string|null $filename The filename to load from
      * @throws Exception if the image format is not supported,
      *  or the file cannot be opened.
      */
@@ -150,7 +151,7 @@ class ImagickEscposImage extends EscposImage
         try {
             $im->setResourceLimit(6, 1); // Prevent libgomp1 segfaults, grumble grumble.
             $im -> readimage($filename);
-        } catch (ImagickException $e) {
+        } catch (\ImagickException $e) {
             /* Re-throw as normal exception */
             throw new Exception($e);
         }
@@ -204,12 +205,12 @@ class ImagickEscposImage extends EscposImage
      *
      * @param string $pdfFile
      *  The file to load
-     * @param string $pageWidth
+     * @param int $pageWidth
      *  The width, in pixels, of the printer's output. The first page of the
      *  PDF will be scaled to approximately fit in this area.
      * @throws Exception Where Imagick is not loaded, or where a missing file
      *  or invalid page number is requested.
-     * @return multitype:EscposImage Array of images, retrieved from the PDF file.
+     * @return array Array of images, retrieved from the PDF file.
      */
     public static function loadPdf($pdfFile, $pageWidth = 550)
     {

--- a/src/Mike42/Escpos/NativeEscposImage.php
+++ b/src/Mike42/Escpos/NativeEscposImage.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
@@ -50,7 +50,7 @@ class EscposPrintBuffer implements PrintBuffer
     private $encode = null;
 
     /**
-     * @var Printer $printer
+     * @var Printer|null $printer
      *  Printer for output
      */
     private $printer;

--- a/src/Mike42/Escpos/PrintBuffers/ImagePrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/ImagePrintBuffer.php
@@ -27,6 +27,9 @@ class ImagePrintBuffer implements PrintBuffer
 {
     private $printer;
 
+    /**
+     * @var string|null font to use
+     */
     private $font;
 
     private $fontSize;
@@ -104,7 +107,7 @@ class ImagePrintBuffer implements PrintBuffer
         if ($this -> printer == null) {
             throw new LogicException("Not attached to a printer.");
         }
-        $this -> printer -> getPrintConnector() -> write($data);
+        $this -> printer -> getPrintConnector() -> write($text);
     }
 
     /**

--- a/src/Mike42/Escpos/PrintBuffers/PrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/PrintBuffer.php
@@ -43,7 +43,7 @@ interface PrintBuffer
     /**
      * Used by Escpos to hook up one-to-one link between buffers and printers.
      *
-     * @param Escpos $printer New printer
+     * @param Printer|null $printer New printer
      */
     public function setPrinter(Printer $printer = null);
 

--- a/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
@@ -50,8 +50,10 @@ class FilePrintConnector implements PrintConnector
      */
     public function finalize()
     {
-        fclose($this -> fp);
-        $this -> fp = false;
+        if ($this -> fp !== false) {
+            fclose($this -> fp);
+            $this -> fp = false;
+        }
     }
     
     /* (non-PHPdoc)
@@ -59,6 +61,9 @@ class FilePrintConnector implements PrintConnector
      */
     public function read($len)
     {
+        if ($this -> fp === false) {
+            throw new Exception("PrintConnector has been closed, cannot read input.");
+        }
         return fread($this -> fp, $len);
     }
     
@@ -69,6 +74,9 @@ class FilePrintConnector implements PrintConnector
      */
     public function write($data)
     {
+        if ($this -> fp === false) {
+            throw new Exception("PrintConnector has been closed, cannot send output.");
+        }
         fwrite($this -> fp, $data);
     }
 }

--- a/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/PrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/PrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/UriPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/UriPrintConnector.php
@@ -5,12 +5,14 @@ namespace Mike42\Escpos\PrintConnectors;
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md
  * for details.
  */
+
+namespace Mike42\Escpos\PrintConnectors;
 
 class UriPrintConnector
 {

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -100,7 +100,7 @@ class WindowsPrintConnector implements PrintConnector
     /**
      * Valid smb:// URI containing hostname & printer with optional user & optional password only.
      */
-    const REGEX_SMB = "/^smb:\/\/([\s\d\w-]+(:[\s\d\w-+]+)?@)?([\d\w-]+\.)*[\d\w-]+\/([\d\w-]+\/)?[\d\w-]+(\s[\d\w-]+)*$/";
+    const REGEX_SMB = "/^smb:\/\/([\s\d\w-]+(:[\s\d\w+-]+)?@)?([\d\w-]+\.)*[\d\w-]+\/([\d\w-]+\/)?[\d\w-]+(\s[\d\w-]+)*$/";
 
     /**
      * @param string $dest

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -1142,7 +1142,7 @@ class Printer
      * Throw an exception if the argument given is not an integer within one of the specified ranges
      *
      * @param int $test the input to test
-     * @param arrray $ranges array of two-item min/max ranges.
+     * @param array $ranges array of two-item min/max ranges.
      * @param string $source the name of the function calling this
      * @param string $source the name of the function calling this
      * @param string $argument the name of the invalid parameter

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -3,7 +3,7 @@
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
  *
- * Copyright (c) 2014-16 Michael Billington < michael.billington@gmail.com >,
+ * Copyright (c) 2014-18 Michael Billington < michael.billington@gmail.com >,
  * incorporating modifications by others. See CONTRIBUTORS.md for a full list.
  *
  * This software is distributed under the terms of the MIT license. See LICENSE.md
@@ -328,7 +328,7 @@ class Printer
     const UNDERLINE_DOUBLE = 2;
 
     /**
-     * @var PrintBuffer $buffer
+     * @var PrintBuffer|null $buffer
      *  The printer's output buffer.
      */
     protected $buffer;
@@ -355,7 +355,7 @@ class Printer
      * Construct a new print object
      *
      * @param PrintConnector $connector The PrintConnector to send data to. If not set, output is sent to standard output.
-     * @param CapabilityProfile $profile Supported features of this printer. If not set, the "default" CapabilityProfile will be used, which is suitable for Epson printers.
+     * @param CapabilityProfile|null $profile Supported features of this printer. If not set, the "default" CapabilityProfile will be used, which is suitable for Epson printers.
      * @throws InvalidArgumentException
      */
     public function __construct(PrintConnector $connector, CapabilityProfile $profile = null)
@@ -636,15 +636,15 @@ class Printer
      * Print a two-dimensional data code using the PDF417 standard.
      *
      * @param string $content Text or numbers to store in the code
-     * @param number $width Width of a module (pixel) in the printed code.
+     * @param int $width Width of a module (pixel) in the printed code.
      *  Default is 3 dots.
-     * @param number $heightMultiplier Multiplier for height of a module.
+     * @param int $heightMultiplier Multiplier for height of a module.
      *  Default is 3 times the width.
-     * @param number $dataColumnCount Number of data columns to use. 0 (default)
+     * @param int $dataColumnCount Number of data columns to use. 0 (default)
      *  is to auto-calculate. Smaller numbers will result in a narrower code,
      *  making larger pixel sizes possible. Larger numbers require smaller pixel sizes.
-     * @param real $ec Error correction ratio, from 0.01 to 4.00. Default is 0.10 (10%).
-     * @param number $options Standard code Printer::PDF417_STANDARD with
+     * @param float $ec Error correction ratio, from 0.01 to 4.00. Default is 0.10 (10%).
+     * @param int $options Standard code Printer::PDF417_STANDARD with
      *  start/end bars, or truncated code Printer::PDF417_TRUNCATED with start bars only.
      * @throws Exception If this profile indicates that PDF417 code is not supported
      */
@@ -869,7 +869,7 @@ class Printer
      *
      * Some printers will allow you to overlap lines with a smaller line feed.
      *
-     * @param int $height The height of each line, in dots. If not set, the printer
+     * @param int|null $height The height of each line, in dots. If not set, the printer
      *  will reset to its default line spacing.
      */
     public function setLineSpacing($height = null)

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -972,7 +972,18 @@ class Printer
         self::validateInteger($underline, 0, 2, __FUNCTION__);
         $this -> connector -> write(self::ESC . "-" . chr($underline));
     }
-    
+
+    /**
+     * Print each line upside-down (180 degrees rotated).
+     *
+     * @param boolean $on True to enable, false to disable.
+     */
+    public function setUpsideDown($on = true)
+    {
+        self::validateBoolean($on, __FUNCTION__);
+        $this -> connector -> write(self::ESC . "{" . ($on ? chr(1) : chr(0)));
+    }
+
     /**
      * Add text to the buffer.
      *

--- a/src/Mike42/Escpos/resources/capabilities.json
+++ b/src/Mike42/Escpos/resources/capabilities.json
@@ -250,6 +250,19 @@
             "name": "ISO_8859-7",
             "python_encode": "iso8859_7"
         },
+        "OXHOO-EUROPEAN": {
+            "data": [
+                "\u00c7\u00fc\u00e9\u00e2\u00e4\u00e0\u00e5\u00e7\u00ea\u00eb\u00e8\u00ef\u00ee\u00ec\u00c4\u00c5",
+                "\u00c9\u00e6\u00c6\u00f4\u00f6\u00f2\u00fb\u00f9\u00ff\u00d6\u00dc\u00f1\u00d1\u00aa\u00ba\u00bf",
+                "\u00e1\u00ed\u00f3\u00fa\u00a2\u00a3\u00a5\u20a7\u0192\u00a1\u00c3\u00e3\u00d5\u00f5\u00d8\u00f8",
+                "\u00b7\u00a8\u00b0`\u00b4\u00bd\u00bc\u00d7\u00f7\u2264\u2265\u00ab\u00bb\u2260\u221a\u00af",
+                "\u2320\u2321\u221e\u25e4\u21b5\u2191\u2193\u2192\u2190\u250c\u2510\u2514\u2518\u2022\u00ae\u00a9",
+                "\u2122\u2020\u00a7\u00b6\u0393\u25e2\u0398         ",
+                "\u00df   \u03b5           ",
+                "\u03c4               "
+            ],
+            "name": "Oxhoo-specific European"
+        },
         "RK1048": {
             "iconv": "RK1048",
             "name": "RK1048"
@@ -286,6 +299,44 @@
         }
     },
     "profiles": {
+        "AF-240": {
+            "codePages": {
+                "0": "OXHOO-EUROPEAN"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeA": false,
+                "barcodeB": false,
+                "bitImageColumn": false,
+                "bitImageRaster": false,
+                "graphics": false,
+                "highDensity": false,
+                "paperFullCut": false,
+                "paperPartCut": false,
+                "pdf417Code": false,
+                "pulseBel": false,
+                "pulseStandard": false,
+                "qrCode": false,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 20,
+                    "name": "Font A"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": 120,
+                    "pixels": 100
+                }
+            },
+            "name": "AF-240 Customer Display",
+            "notes": "This is a two-line, ESC/POS-aware customer display from Oxhoo. The ESC/POS command mode can be activated persistently by sending:\n\n    echo -ne \"\\n\\x02\\x05\\x43\\x31\\x03\" > /dev/ttyUSB0\n",
+            "vendor": "Oxhoo"
+        },
         "NT-5890K": {
             "codePages": {
                 "0": "CP437",
@@ -395,6 +446,62 @@
             "notes": "",
             "vendor": "Netum"
         },
+        "OCD-100": {
+            "codePages": {
+                "0": "CP437",
+                "1": "CP932",
+                "2": "CP850",
+                "3": "CP860",
+                "4": "CP863",
+                "5": "CP865",
+                "6": "Unknown",
+                "7": "Unknown",
+                "8": "Unknown",
+                "9": "CP852",
+                "10": "CP862",
+                "11": "CP866",
+                "12": "CP1251",
+                "13": "CP1254",
+                "14": "CP1255",
+                "15": "CP1257",
+                "16": "CP1252",
+                "17": "CP1253",
+                "19": "CP858"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeA": false,
+                "barcodeB": false,
+                "bitImageColumn": false,
+                "bitImageRaster": false,
+                "graphics": false,
+                "highDensity": false,
+                "paperFullCut": false,
+                "paperPartCut": false,
+                "pdf417Code": false,
+                "pulseBel": false,
+                "pulseStandard": false,
+                "qrCode": false,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 20,
+                    "name": "Font A"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": 180,
+                    "pixels": 100
+                }
+            },
+            "name": "OCD-100 Customer Display",
+            "notes": "This is a two-line, ESC/POS-aware customer display from Aures. It has some graphics support via custom fonts, but is otherwise text-only. This profile is also suitable for the OCD-150 pole-mounted display.\n",
+            "vendor": "Aures"
+        },
         "OCD-300": {
             "codePages": {
                 "0": "CP437",
@@ -428,12 +535,12 @@
                 "bitImageColumn": false,
                 "bitImageRaster": false,
                 "graphics": false,
-                "highDensity": true,
+                "highDensity": false,
                 "paperFullCut": false,
                 "paperPartCut": false,
                 "pdf417Code": false,
                 "pulseBel": false,
-                "pulseStandard": true,
+                "pulseStandard": false,
                 "qrCode": false,
                 "starCommands": false
             },
@@ -445,11 +552,11 @@
             },
             "media": {
                 "width": {
-                    "mm": "Unknown",
-                    "pixels": "Unknown"
+                    "mm": 130.2,
+                    "pixels": 240
                 }
             },
-            "name": "Aures OCP-300 Customer Display",
+            "name": "OCD-300 Customer Display",
             "notes": "This is a two-line, ESC/POS-aware customer display from Aures. It has some graphics support via vendor-provided tools, but is otherwise text-only.\n",
             "vendor": "Aures"
         },

--- a/src/Mike42/Escpos/resources/capabilities.json
+++ b/src/Mike42/Escpos/resources/capabilities.json
@@ -1182,6 +1182,105 @@
             "notes": "Epson TM-T88III profile. This printer has similar feature support to the TM-T88II. The code page mapping is documented in the \"TM-T88II/T88III Technical Reference Guide\".\n",
             "vendor": "Epson"
         },
+        "TM-T88IV": {
+            "codePages": {
+                "0": "CP437",
+                "1": "CP932",
+                "2": "CP850",
+                "3": "CP860",
+                "4": "CP863",
+                "5": "CP865",
+                "16": "CP1252",
+                "17": "CP866",
+                "18": "CP852",
+                "19": "CP858",
+                "255": "Unknown"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeA": true,
+                "barcodeB": true,
+                "bitImageColumn": true,
+                "bitImageRaster": true,
+                "graphics": true,
+                "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
+                "pdf417Code": true,
+                "pulseBel": false,
+                "pulseStandard": true,
+                "qrCode": true,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 42,
+                    "name": "Font A"
+                },
+                "1": {
+                    "columns": 56,
+                    "name": "Font B"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": "Unknown",
+                    "pixels": "Unknown"
+                }
+            },
+            "name": "TM-T88IV",
+            "notes": "Epson TM-T88IV profile\n",
+            "vendor": "Epson"
+        },
+        "TM-T88IV-SA": {
+            "codePages": {
+                "0": "CP437",
+                "20": "Unknown",
+                "21": "CP874",
+                "26": "Unknown",
+                "30": "TCVN-3-1",
+                "31": "TCVN-3-2"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeA": true,
+                "barcodeB": true,
+                "bitImageColumn": true,
+                "bitImageRaster": true,
+                "graphics": true,
+                "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
+                "pdf417Code": true,
+                "pulseBel": false,
+                "pulseStandard": true,
+                "qrCode": true,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 42,
+                    "name": "Font A"
+                },
+                "1": {
+                    "columns": 56,
+                    "name": "Font B"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": "Unknown",
+                    "pixels": "Unknown"
+                }
+            },
+            "name": "TM-T88IV South Asia",
+            "notes": "Epson TM-T88IV profile (South Asia models)\n",
+            "vendor": "Epson"
+        },
         "TM-U220": {
             "codePages": {
                 "0": "CP437"

--- a/src/Mike42/Escpos/resources/capabilities.json
+++ b/src/Mike42/Escpos/resources/capabilities.json
@@ -286,6 +286,115 @@
         }
     },
     "profiles": {
+        "NT-5890K": {
+            "codePages": {
+                "0": "CP437",
+                "1": "CP932",
+                "2": "CP850",
+                "3": "CP860",
+                "4": "CP863",
+                "5": "CP865",
+                "6": "Unknown",
+                "7": "Unknown",
+                "8": "Unknown",
+                "9": "Unknown",
+                "10": "Unknown",
+                "16": "CP1252",
+                "17": "CP866",
+                "18": "CP852",
+                "19": "CP858",
+                "20": "Unknown",
+                "21": "Unknown",
+                "22": "Unknown",
+                "23": "Unknown",
+                "24": "CP747",
+                "25": "CP1257",
+                "27": "CP1258",
+                "28": "CP864",
+                "31": "Unknown",
+                "32": "CP1255",
+                "50": "CP437",
+                "52": "CP437",
+                "53": "CP858",
+                "54": "CP852",
+                "55": "CP860",
+                "56": "CP861",
+                "57": "CP863",
+                "58": "CP865",
+                "59": "CP866",
+                "60": "CP855",
+                "61": "CP857",
+                "62": "CP862",
+                "63": "CP864",
+                "64": "CP737",
+                "65": "CP851",
+                "66": "CP869",
+                "68": "CP772",
+                "69": "CP774",
+                "71": "CP1252",
+                "72": "CP1250",
+                "73": "CP1251",
+                "74": "CP3840",
+                "76": "CP3843",
+                "77": "CP3844",
+                "78": "CP3845",
+                "79": "CP3846",
+                "80": "CP3847",
+                "81": "CP3848",
+                "83": "CP2001",
+                "84": "CP3001",
+                "85": "CP3002",
+                "86": "CP3011",
+                "87": "CP3012",
+                "88": "CP3021",
+                "89": "CP3041",
+                "90": "CP1253",
+                "91": "CP1254",
+                "92": "CP1256",
+                "93": "CP720",
+                "94": "CP1258",
+                "95": "CP775",
+                "96": "Unknown",
+                "255": "Unknown"
+            },
+            "colors": {
+                "0": "black"
+            },
+            "features": {
+                "barcodeA": false,
+                "barcodeB": false,
+                "bitImageColumn": true,
+                "bitImageRaster": true,
+                "graphics": false,
+                "highDensity": true,
+                "paperFullCut": false,
+                "paperPartCut": false,
+                "pdf417Code": false,
+                "pulseBel": false,
+                "pulseStandard": true,
+                "qrCode": false,
+                "starCommands": false
+            },
+            "fonts": {
+                "0": {
+                    "columns": 32,
+                    "name": "Font A"
+                },
+                "1": {
+                    "columns": 42,
+                    "name": "Font B"
+                }
+            },
+            "media": {
+                "width": {
+                    "mm": 57.5,
+                    "pixels": 384
+                }
+            },
+            "name": "NT-5890K",
+            "notes": "",
+            "vendor": "Netum"
+        },
         "OCD-300": {
             "codePages": {
                 "0": "CP437",
@@ -314,11 +423,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": false,
                 "barcodeB": false,
                 "bitImageColumn": false,
                 "bitImageRaster": false,
                 "graphics": false,
                 "highDensity": true,
+                "paperFullCut": false,
+                "paperPartCut": false,
                 "pdf417Code": false,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -419,11 +531,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": false,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -525,11 +640,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": false,
                 "barcodeB": false,
                 "bitImageColumn": false,
                 "bitImageRaster": true,
                 "graphics": false,
                 "highDensity": true,
+                "paperFullCut": false,
+                "paperPartCut": false,
                 "pdf417Code": false,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -538,18 +656,18 @@
             },
             "fonts": {
                 "0": {
-                    "columns": 42,
+                    "columns": 32,
                     "name": "Font A"
                 },
                 "1": {
-                    "columns": 56,
+                    "columns": 42,
                     "name": "Font B"
                 }
             },
             "media": {
                 "width": {
-                    "mm": "Unknown",
-                    "pixels": "Unknown"
+                    "mm": 57.5,
+                    "pixels": 384
                 }
             },
             "name": "POS5890 Series",
@@ -612,11 +730,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -712,11 +833,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -812,11 +936,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -916,11 +1043,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -966,11 +1096,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1015,11 +1148,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1055,11 +1191,14 @@
                 "1": "alternate"
             },
             "features": {
+                "barcodeA": false,
                 "barcodeB": false,
                 "bitImageColumn": true,
                 "bitImageRaster": false,
                 "graphics": false,
                 "highDensity": false,
+                "paperFullCut": false,
+                "paperPartCut": false,
                 "pdf417Code": false,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1142,11 +1281,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1229,11 +1371,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1329,11 +1474,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": true,
                 "barcodeB": true,
                 "bitImageColumn": true,
                 "bitImageRaster": true,
                 "graphics": true,
                 "highDensity": true,
+                "paperFullCut": true,
+                "paperPartCut": true,
                 "pdf417Code": true,
                 "pulseBel": false,
                 "pulseStandard": true,
@@ -1368,11 +1516,14 @@
                 "0": "black"
             },
             "features": {
+                "barcodeA": false,
                 "barcodeB": false,
                 "bitImageColumn": false,
                 "bitImageRaster": true,
                 "graphics": false,
                 "highDensity": true,
+                "paperFullCut": false,
+                "paperPartCut": false,
                 "pdf417Code": false,
                 "pulseBel": false,
                 "pulseStandard": true,

--- a/test/unit/EscposTest.php
+++ b/test/unit/EscposTest.php
@@ -1100,6 +1100,13 @@ class EscposTest extends PHPUnit_Framework_TestCase
         $this -> printer -> setPrintLeftMargin(70000);
         $this -> checkOutput();
     }
+
+    /* Upside-down print */
+    public function testSetUpsideDown()
+    {
+        $this -> printer -> setUpsideDown(true);
+        $this -> checkOutput("\x1b@\x1b{\x01");
+    }
 }
 
 /*

--- a/test/unit/FilePrintConnectorTest.php
+++ b/test/unit/FilePrintConnectorTest.php
@@ -1,0 +1,26 @@
+<?php
+use Mike42\Escpos\PrintConnectors\FilePrintConnector;
+
+class FilePrintConnectorTest extends PHPUnit_Framework_TestCase
+{
+    public function testTmpfile()
+    {
+        // Should attempt to send data to the local printer by writing to it
+        $tmpfname = tempnam("/tmp", "php");
+        $connector = new FilePrintConnector($tmpfname);
+        $connector -> finalize();
+        $connector -> finalize(); // Silently do nothing if printer already closed
+        unlink($tmpfname);
+    }
+    
+    public function testReadAfterClose()
+    {
+        // Should attempt to send data to the local printer by writing to it
+        $this -> setExpectedException('Exception');
+        $tmpfname = tempnam("/tmp", "php");
+        $connector = new FilePrintConnector($tmpfname);
+        $connector -> finalize();
+        $connector -> write("Test");
+        unlink($tmpfname);
+    }
+}


### PR DESCRIPTION
New features:

- Upside-down printing is now implemented #615
- Include updates from the [escpos-printer-db](https://github.com/receipt-print-hq/escpos-printer-db)

Bug and code fixes:

-  Modify validation code in `WindowsPrintConnector` for PHP 7.3 compatibility
- Add to type hints where possible, replace old usages in examples, and correctly label the namespace for some exceptions

Newly tested printers:

- OKI RT322
- ithaca ITherm 280
- Rongta RP80USE
- Sewoo SLK-TS400
- Approx APPPOS80AM
- QPOS Q58M
- HOIN HOP-H58
- Xeumior SM-8330
- Birch PRP-085III
- 3nStar RPT-008
- POSLIGNE ODP200H-III-G
