### PR TITLE
Add printers tested since previous release

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,16 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Bematech LR2000E
 - Birch PRP-085III
 - Bixolon SRP-350III
+- Bixolon SRP-350Plus
 - Black Copper BC-85AC
+- CHD TH-305N
 - Citizen CBM1000-II
 - Citizen CT-S310II
 - Dapper-Geyi Q583P 
 - Daruma DR800
 - DR-MP200 (manufacturer unknown)
 - EPOS TEP 220M
+- Elgin i9
 - Epson EU-T332C
 - Epson FX-890 (requires `feedForm()` to release paper).
 - Epson TM-T20
@@ -98,9 +101,11 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Epson TM-U295 (requires `release()` to release slip).
 - Epson TM-U590 and TM-U590P
 - Equal (EQ-IT-001) POS-58
+- Everycom EC-58
 - Excelvan HOP-E200 
 - Excelvan HOP-E58
 - Excelvan HOP-E801
+- Gainscha GP-2120TF
 - Gainscha GP-5890x (Also marketed as EC Line 5890x)
 - Gainscha GP-U80300I (Also marketed as gprinter GP-U80300I)
 - gprinter GP-U80160I
@@ -122,9 +127,13 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Rongta RP326US
 - Rongta RP58-U
 - Rongta RP80USE
+- SAM4S GIANT-100DB
 - Senor TP-100
 - Sewoo SLK-TS400
+- SEYPOS PRP-96
 - SEYPOS PRP-300 (Also marketed as TYSSO PRP-300)
+- SNBC BTP-R880NPIII
+- Solux SX-TP-88300
 - Sicar POS-80
 - Silicon SP-201 / RP80USE
 - SPRT SP-POS88V
@@ -133,6 +142,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Star TSP100III FuturePRNT
 - Star TSP-650
 - Star TUP-592
+- TVS RP45 Shoppe
 - Venus V248T
 - Xeumior SM-8330
 - Xprinter F-900
@@ -146,6 +156,7 @@ Many thermal receipt printers support ESC/POS to some degree. This driver has be
 - Zjiang ZJ-5870
 - Zjiang ZJ-5890 (Also sold as POS-5890 by many vendors; ZJ-5890K, ZJ-5890T also work).
 - Zjiang ZJ-8220 (Also marketed as Excelvan ZJ-8220)
+- Zjiang ZJ-8250
 
 If you use any other printer with this code, please [let us know](https://github.com/mike42/escpos-php/issues/new) so that it can be added to the list.
 


### PR DESCRIPTION
This change adds printers to the README based on reports that they have been successfully used with this driver-

- Bixolon SRP-350Plus #786
- CHD TH-305N #798
- Elgin i9 #689
- Everycom EC-58 #778
- Gainscha GP-2120TF #766
- SAM4S GIANT-100DB #781
- Sewoo SLK-400 Bluetooth/USB version (similar model already listed, no change) #746
- SEYPOS PRP-96 #705
- Solux SX-TP-88300 #749
- SNBC BTP-R880NPIII #714
- TVS RP45 Shoppe #778
- Zjiang ZJ-8250 #694
