### PR TITLE
Add checks for failed tmp file creation

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
@@ -78,6 +78,9 @@ class CupsPrintConnector implements PrintConnector
         
         // Build command to work on data
         $tmpfname = tempnam(sys_get_temp_dir(), 'print-');
+        if ($tmpfname === false) {
+            throw new Exception("Failed to create temp file for printing.");
+        }
         file_put_contents($tmpfname, $data);
         $cmd = sprintf(
             "lp -d %s %s",

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -286,6 +286,9 @@ class WindowsPrintConnector implements PrintConnector
             }
             /* Final print-out */
             $filename = tempnam(sys_get_temp_dir(), "escpos");
+            if ($filename === false) {
+                throw new Exception("Failed to create temp file for printing.");
+            }
             file_put_contents($filename, $data);
             if (!$this -> runCopy($filename, $device)) {
                 throw new Exception("Failed to copy file to printer");


### PR DESCRIPTION
This gives a clearer error in situations where `/tmp` is full or has permissions issues.

Ref:

- #362