### PR TITLE
Update example autoload paths

### DIFF
--- a/example/interface/cups.php
+++ b/example/interface/cups.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\CupsPrintConnector;
 

--- a/example/interface/ethernet.php
+++ b/example/interface/ethernet.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\NetworkPrintConnector;
 

--- a/example/interface/linux-usb.php
+++ b/example/interface/linux-usb.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\FilePrintConnector;
 

--- a/example/interface/smb.php
+++ b/example/interface/smb.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\WindowsPrintConnector;
 

--- a/example/interface/windows-lpt.php
+++ b/example/interface/windows-lpt.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\WindowsPrintConnector;
 

--- a/example/interface/windows-usb.php
+++ b/example/interface/windows-usb.php
@@ -1,6 +1,6 @@
 <?php
 /* Change to the correct path if you copy this example! */
-require __DIR__ . '/../../autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 use Mike42\Escpos\Printer;
 use Mike42\Escpos\PrintConnectors\WindowsPrintConnector;
 


### PR DESCRIPTION
The `interface` examples pointed at the bundled `autoload.php` file, which was removed in 3.0.

This change points them at `vendor/autoload.php`, which will exist if this repository is being used standalone.

Ref:
- #825