### PR TITLE
Add strict types to CodePage, ImagickEscposImage, NetworkPrintConnector and Printer and fix the code

### DIFF
--- a/src/Mike42/Escpos/CodePage.php
+++ b/src/Mike42/Escpos/CodePage.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types=1);
 /**
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
@@ -166,7 +165,7 @@ class CodePage
             // Try to identify the UTF-8 character at this position in the code page
             $encodingChar = chr($char);
             $utf8 = $converter ->convert($encodingChar, false);
-            if ($utf8 === $missingChar) {
+            if ($utf8 === $missingChar || $utf8 === false) {
                 // Cannot be mapped to unicode
                 continue;
             }

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types=1);
 /**
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
@@ -122,11 +121,11 @@ class ImagickEscposImage extends EscposImage
             $widthRight = $imgWidth - $widthLeft;
             // Slice up (left)
             $left = clone $im;
-            $left -> extentimage($widthLeft, $left -> getimageheight(), 0, 0);
+            $left -> extentimage((int)$widthLeft, $left -> getimageheight(), 0, 0);
             // Slice up (right - ensure width is divisible by lineHeight also)
             $right = clone $im;
             $widthRightRounded = $widthRight < $lineHeight ? $lineHeight : $widthRight;
-            $right -> extentimage($widthRightRounded, $right -> getimageheight(), $widthLeft, 0);
+            $right -> extentimage((int)$widthRightRounded, $right -> getimageheight(), (int) $widthLeft, 0);
             // Recurse
             $leftBlobs = $this -> getColumnFormatFromImage($left, $lineHeight);
             $rightBlobs = $this -> getColumnFormatFromImage($right, $lineHeight);
@@ -153,7 +152,7 @@ class ImagickEscposImage extends EscposImage
             $im -> readimage($filename);
         } catch (\ImagickException $e) {
             /* Re-throw as normal exception */
-            throw new Exception($e);
+            throw new Exception((string)$e);
         }
         return $im;
     }
@@ -247,7 +246,7 @@ class ImagickEscposImage extends EscposImage
         } catch (\ImagickException $e) {
             /* Wrap in normal exception, so that classes which call this do not
              * themselves require imagick as a dependency. */
-            throw new Exception($e);
+            throw new Exception((string)$e);
         }
     }
 

--- a/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/NetworkPrintConnector.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types=1);
 /**
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
@@ -31,7 +30,7 @@ class NetworkPrintConnector extends FilePrintConnector
     public function __construct(string $ip, int $port = 9100, bool $timeout = false)
     {
         // Default to 60 if default_socket_timeout isn't defined in the ini
-        $defaultSocketTimeout = ini_get("default_socket_timeout") ?: 60;
+        $defaultSocketTimeout = (int)ini_get("default_socket_timeout") ?: 60;
         $timeout = $timeout ?: $defaultSocketTimeout;
 
         $this -> fp = @fsockopen($ip, $port, $errno, $errstr, $timeout);

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types=1);
 /**
  * This file is part of escpos-php: PHP receipt printer library for use with
  * ESC/POS-compatible thermal and impact printers.
@@ -691,7 +690,7 @@ class Printer
         self::validateInteger($pin, 0, 1, __FUNCTION__);
         self::validateInteger($on_ms, 1, 511, __FUNCTION__);
         self::validateInteger($off_ms, 1, 511, __FUNCTION__);
-        $this -> connector -> write(self::ESC . "p" . chr($pin + 48) . chr($on_ms / 2) . chr($off_ms / 2));
+        $this -> connector -> write(self::ESC . "p" . chr($pin + 48) . chr((int)($on_ms / 2)) . chr((int)($off_ms / 2)));
     }
 
     /**

--- a/test/integration/ExampleTest.php
+++ b/test/integration/ExampleTest.php
@@ -194,7 +194,7 @@ class ExampleTest extends PHPUnit\Framework\TestCase
     protected function requireGraphicsLibrary()
     {
         if (!EscposImage::isGdLoaded() && !EscposImage::isImagickLoaded()) {
-            $this -> markTestSkipped("This test requires a graphics library.");
+            $this -> markTestSkipped("gd and imagick plugin are required for this test");
         }
     }
 }

--- a/test/unit/GdEscposImageTest.php
+++ b/test/unit/GdEscposImageTest.php
@@ -69,7 +69,7 @@ class GdEscposImageTest extends PHPUnit\Framework\TestCase
     private function loadAndCheckImg($fn, $width, $height, $rasterFormat = null, $columnFormat = null)
     {
         if (!EscposImage::isGdLoaded()) {
-            $this -> markTestSkipped("imagick plugin is required for this test");
+            $this -> markTestSkipped("gd plugin is required for this test");
         }
         $onDisk = ($fn === null ? null : (dirname(__FILE__) . "/resources/$fn"));
         // With optimisations


### PR DESCRIPTION
Hi! This PR fixes #879.

Add `declare(strict_types=1);` to:
- [x] CodePage
- [x] ImagickEscposImage
- [x] NetworkPrintConnector
- [x] Printer

For each class, I have:
1. added strict_types;
1. ran tests;
1. and fixed the actual code.
    * In general, I only made some castings to fix.

----

This was the trickiest fix: https://github.com/mike42/escpos-php/commit/0c5d2694752c77590a899aa661e8a72e710375bd. Check the commit message for more details. It would be a good idea to upgrade PHP.