### PR TITLE
Added ability to request CUPS Job Number and the amount of pages printed

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
@@ -37,6 +37,20 @@ class CupsPrintConnector implements PrintConnector
      *  The name of the target printer.
      */
     private $printerName;
+
+    /**
+     *
+     * @var int $jobNumber
+     *  The job dispatch number
+     */
+    private $jobNumber;
+
+    /**
+     *
+     * @var int amountPages
+     *  The amount of pages that CUPS reported to print
+     */
+    private $amountPages;
     
     /**
      * Construct new CUPS print connector.
@@ -91,12 +105,36 @@ class CupsPrintConnector implements PrintConnector
             escapeshellarg($tmpfname)
         );
         try {
-            $this->getCmdOutput($cmd);
+            $response = $this->getCmdOutput($cmd);
+            $exploded = explode(" ", $response);
+            $jobName = explode("-", $exploded[3]);
+            $this->jobNumber = intval($jobName[count($jobName) - 1]);
+            $this->amountPages = intval(substr($exploded[4], 1));
         } catch (Exception $e) {
             unlink($tmpfname);
             throw $e;
         }
         unlink($tmpfname);
+    }
+
+    /**
+     * Retrieve the job number
+     *
+     * @return int Assigned job number, or null if the job has not yet been finalized.
+     */
+    public function getJobNumber()
+    {
+        return $this->jobNumber;
+    }
+
+    /**
+     * Retrieve the amount of files printed
+     *
+     * @return in The amount of files CUPS reported to print, or null if the job has not yet been finalized.
+     */
+    public function getAmountPages()
+    {
+        return $this->amountPages;
     }
     
     /**

--- a/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
@@ -107,9 +107,19 @@ class CupsPrintConnector implements PrintConnector
         try {
             $response = $this->getCmdOutput($cmd);
             $exploded = explode(" ", $response);
-            $jobName = explode("-", $exploded[3]);
-            $this->jobNumber = intval($jobName[count($jobName) - 1]);
-            $this->amountPages = intval(substr($exploded[4], 1));
+
+            // Set default data in case the checks fail, and make them obvioulsy incorrect
+            $this->jobNumber = -1;
+            $this->amountPages = -1;
+
+            if (count($exploded) > 3) {
+                $jobName = explode("-", $exploded[3]);
+                $this->jobNumber = intval($jobName[count($jobName) - 1]);
+            }
+
+            if (count($exploded) > 4) {
+                $this->amountPages = intval(substr($exploded[4], 1));
+            }
         } catch (Exception $e) {
             unlink($tmpfname);
             throw $e;

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -1033,7 +1033,8 @@ class Printer
      */
     public function getJobNumber()
     {
-        if (! $this -> connector instanceof CupsPrintConnector) {
+        if (! $this -> connector instanceof \Mike42\Escpos\PrintConnectors\CupsPrintConnector) {
+            echo "Connector is not cupsprintconnector\n";
             return null;
         }
 
@@ -1047,7 +1048,8 @@ class Printer
      */
     public function getAmountPages()
     {
-        if (! $this -> connector instanceof CupsPrintConnector) {
+        if (! $this -> connector instanceof \Mike42\Escpos\PrintConnectors\CupsPrintConnector) {
+            echo "connector is not cupsprintconnector\n";
             return null;
         }
 

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -1034,7 +1034,6 @@ class Printer
     public function getJobNumber()
     {
         if (! $this -> connector instanceof \Mike42\Escpos\PrintConnectors\CupsPrintConnector) {
-            echo "Connector is not cupsprintconnector\n";
             return null;
         }
 
@@ -1049,7 +1048,6 @@ class Printer
     public function getAmountPages()
     {
         if (! $this -> connector instanceof \Mike42\Escpos\PrintConnectors\CupsPrintConnector) {
-            echo "connector is not cupsprintconnector\n";
             return null;
         }
 

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -1025,6 +1025,34 @@ class Printer
     {
         $this -> buffer -> writeTextRaw((string)$str);
     }
+
+    /**
+     * Returns job number assigned, only available if CupsPrintConnector has been used
+     *
+     * @return int Assigned job number, or null if the job has not yet been finalized or the printconnector does not support this function
+     */
+    public function getJobNumber()
+    {
+        if (! $this -> connector instanceof CupsPrintConnector) {
+            return null;
+        }
+
+        return $this -> connector -> getJobNumber();
+    }
+
+    /**
+     * Returns amount of pages printed, only available if CupsPrintConnector has been used
+     *
+     * @return int Amount of pages printed, or null if the job has not yet been finalized or the printconnector does not support this function
+     */
+    public function getAmountPages()
+    {
+        if (! $this -> connector instanceof CupsPrintConnector) {
+            return null;
+        }
+
+        return $this -> connector -> getAmountPages();
+    }
     
     /**
      * Wrapper for GS ( k, to calculate and send correct data length.


### PR DESCRIPTION
I found myself in the need of retrieving the job number from CUPS, therefore I implemented it. I added guards for the Printer class, as if it is not using a `CupsPrinterConnector` it should not return these values. I found the amount of files was also returned, so I added it as well. 

The command `lp -d <queue name> <file name>` returns in the format `request id is <queue name>-<job name> (<amt of files> file(s))`. As the job name never contains a dash, we can safely say that the last part of this word, after the last dash, will be the job number. The "word" containing the amount of files is only preceded by a `(`, thus stripping the first letter of this string should always return the number given. 

I was not sure if you are okay with these functions residing also inside of the `Printer`. But you can remove them if you feel that's nicer, as it functionality for a specific connector (but I felt this data should come from the printer, and not the connector).