### PR TITLE
Use of special characters (ÄÜÖ) in receipt examples

### DIFF
--- a/example/rawbt-receipt.php
+++ b/example/rawbt-receipt.php
@@ -130,7 +130,7 @@ class item
         if ($this->dollarSign) {
             $leftCols = $leftCols / 2 - $rightCols / 2;
         }
-        $left = str_pad($this->name, $leftCols);
+        $left = utf8_encode(str_pad(utf8_decode($this -> name), $leftCols));
 
         $sign = ($this->dollarSign ? '$ ' : '');
         $right = str_pad($sign . $this->price, $rightCols, ' ', STR_PAD_LEFT);

--- a/example/receipt-with-logo.php
+++ b/example/receipt-with-logo.php
@@ -95,7 +95,7 @@ class item
         if ($this -> dollarSign) {
             $leftCols = $leftCols / 2 - $rightCols / 2;
         }
-        $left = str_pad($this -> name, $leftCols) ;
+        $left = utf8_encode(str_pad(utf8_decode($this -> name), $leftCols));
         
         $sign = ($this -> dollarSign ? '$ ' : '');
         $right = str_pad($sign . $this -> price, $rightCols, ' ', STR_PAD_LEFT);


### PR DESCRIPTION
Up to now, if special characters such as ÄÜÖ were used in the receipt examples, there were problems with the distance to the margin.
It looked like this:

![image](https://user-images.githubusercontent.com/78685408/174645583-74490484-fabe-49b4-a82d-86811fa07bea.png)

With function utf8_decode before str_pad so that the margin is calculated "correctly" and utf8_encode after it, it works as it should:

![image](https://user-images.githubusercontent.com/78685408/174645769-72587e16-cd14-43ec-944c-41477d365f06.png)

_(The printer I use is the Epson TM-T88IV)_
