### PR TITLE
Macroable Printer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"ext-json": "*",
 		"ext-intl": "*",
 		"ext-zlib": "*",
+                "illuminate/macroable" : ">=6.0",
 		"mike42/gfx-php" : "^0.6"
 	},
 	"suggest" : {

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -13,6 +13,7 @@
 namespace Mike42\Escpos;
 
 use Exception;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Mike42\Escpos\PrintBuffers\PrintBuffer;
 use Mike42\Escpos\PrintBuffers\EscposPrintBuffer;
@@ -23,6 +24,7 @@ use Mike42\Escpos\PrintConnectors\PrintConnector;
  */
 class Printer
 {
+    use Macroable;
     /**
      * ASCII null control character
      */


### PR DESCRIPTION
It would be very helpful if you could create macros on the printer class, it could simplify common tasks, for example:

**Here, you create 'Item' class for formating a line**
https://github.com/mike42/escpos-php/blob/f414320fc510afcacd4cbb75902f827399dee429/example/rawbt-receipt.php#L16-L21
https://github.com/mike42/escpos-php/blob/f414320fc510afcacd4cbb75902f827399dee429/example/rawbt-receipt.php#L126-L138
**With a macro we can do**
```php
Printer::macro('item', function($name = '', $price = '', $dollarSign = false, $width = 48){
        $rightCols = 10;
        $leftCols = $width - $rightCols;
        if ($dollarSign) {
            $leftCols = $leftCols / 2 - $rightCols / 2;
        }
        $left = str_pad($name, $leftCols);

        $sign = ($dollarSign ? '$ ' : '');
        $right = str_pad($sign . $price, $rightCols, ' ', STR_PAD_LEFT);
        return "$left$right\n";
});

//Example
$printer->item('Total', '14.25', true);
```
I could add some test if it is needed, also i could add macro code to printer class to avoid third party dependency
