### PR TITLE
Added cut and eject for printer with eject

### DIFF
--- a/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/CupsPrintConnector.php
@@ -67,7 +67,7 @@ class CupsPrintConnector implements PrintConnector
     public function __destruct()
     {
         if ($this->buffer !== null) {
-            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+            throw new Exception("Print connector was not finalized. Did you forget to close the printer?");
         }
     }
     

--- a/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/DummyPrintConnector.php
@@ -48,7 +48,7 @@ final class DummyPrintConnector implements PrintConnector
     public function __destruct()
     {
         if ($this -> buffer !== null) {
-            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+            throw new Exception("Print connector was not finalized. Did you forget to close the printer?");
         }
     }
 

--- a/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/FilePrintConnector.php
@@ -44,7 +44,7 @@ class FilePrintConnector implements PrintConnector
     public function __destruct()
     {
         if ($this -> fp !== false) {
-            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+            throw new Exception("Print connector was not finalized. Did you forget to close the printer?");
         }
     }
 

--- a/src/Mike42/Escpos/PrintConnectors/RawbtPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/RawbtPrintConnector.php
@@ -49,7 +49,7 @@ final class RawbtPrintConnector implements PrintConnector
     public function __destruct()
     {
         if ($this->buffer !== null) {
-            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+            throw new Exception("Print connector was not finalized. Did you forget to close the printer?");
         }
     }
 

--- a/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
+++ b/src/Mike42/Escpos/PrintConnectors/WindowsPrintConnector.php
@@ -164,7 +164,7 @@ class WindowsPrintConnector implements PrintConnector
     public function __destruct()
     {
         if ($this -> buffer !== null) {
-            trigger_error("Print connector was not finalized. Did you forget to close the printer?", E_USER_NOTICE);
+            throw new Exception("Print connector was not finalized. Did you forget to close the printer?");
         }
     }
 

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -572,6 +572,14 @@ class Printer
     }
 
     /**
+     * Emit a sound with a internal buzzer
+     */
+    public function buzzer()
+    {
+        $this->connector->write(PRINTER::FS . "\xc0" . "\x07");
+    }
+
+    /**
      * Some slip printers require `ESC q` sequence to release the paper.
      */
     public function release()


### PR DESCRIPTION

Added paper cut and eject functions for printer models with paper output control.

```php

    $printer->cut(CUT_FULL_EJECT); // Make a total cut and completely eject sheet
   
    $printer->cut(CUT_FULL_PARTIAL_EJECT); // Make a total cut and partial eject sheet

```
`$lines` are not supported

Below is an example of how it works

Youtube example
[https://youtu.be/HkkgdSfYmbI?t=120](url)