### PR TITLE
require mbstring extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"ext-json": "*",
 		"ext-intl": "*",
 		"ext-zlib": "*",
+		"ext-mbstring": "*",
 		"mike42/gfx-php" : "^0.6"
 	},
 	"suggest" : {


### PR DESCRIPTION
Hi there!

This extension is required to use the library. I can see it was previously included in the list of required extensions, but now it is not. https://github.com/mike42/escpos-php/issues/201