### PR TITLE
Add explicit nullable types to fix implicit-nullable deprecations on PHP 8.4

### DIFF
--- a/src/Mike42/Escpos/EscposImage.php
+++ b/src/Mike42/Escpos/EscposImage.php
@@ -198,7 +198,7 @@ abstract class EscposImage
      *
      * @param string|null $filename Filename to load from.
      */
-    protected function loadImageData(string $filename = null)
+    protected function loadImageData(?string $filename = null)
     {
         // Load image in to string of 1's and 0's, also set width & height
         $this -> setImgWidth(0);

--- a/src/Mike42/Escpos/Experimental/Unifont/UnifontPrintBuffer.php
+++ b/src/Mike42/Escpos/Experimental/Unifont/UnifontPrintBuffer.php
@@ -77,7 +77,7 @@ class UnifontPrintBuffer implements PrintBuffer
     {
     }
     
-    public function setPrinter(Printer $printer = null)
+    public function setPrinter(?Printer $printer = null)
     {
         $this -> printer = $printer;
         $this -> fontMap = new FontMap($this -> unifont, $this -> printer);

--- a/src/Mike42/Escpos/GdEscposImage.php
+++ b/src/Mike42/Escpos/GdEscposImage.php
@@ -29,7 +29,7 @@ class GdEscposImage extends EscposImage
      * @throws Exception if the image format is not supported,
      *  or the file cannot be opened.
      */
-    protected function loadImageData(string $filename = null)
+    protected function loadImageData(?string $filename = null)
     {
         if ($filename === null) {
             /* Set to blank image */

--- a/src/Mike42/Escpos/ImagickEscposImage.php
+++ b/src/Mike42/Escpos/ImagickEscposImage.php
@@ -88,7 +88,7 @@ class ImagickEscposImage extends EscposImage
      * @throws Exception if the image format is not supported,
      *  or the file cannot be opened.
      */
-    protected function loadImageData(string $filename = null)
+    protected function loadImageData(?string $filename = null)
     {
         if ($filename === null) {
             /* Set to blank image */

--- a/src/Mike42/Escpos/NativeEscposImage.php
+++ b/src/Mike42/Escpos/NativeEscposImage.php
@@ -22,7 +22,7 @@ use Mike42\GfxPhp\Image;
  */
 class NativeEscposImage extends EscposImage
 {
-    protected function loadImageData(string $filename = null)
+    protected function loadImageData(?string $filename = null)
     {
         $image = Image::fromFile($filename) -> toRgb() -> toBlackAndWhite();
         $imgHeight = $image -> getHeight();

--- a/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/EscposPrintBuffer.php
@@ -75,7 +75,7 @@ class EscposPrintBuffer implements PrintBuffer
         return $this -> printer;
     }
 
-    public function setPrinter(Printer $printer = null)
+    public function setPrinter(?Printer $printer = null)
     {
         $this -> printer = $printer;
         if ($printer != null) {

--- a/src/Mike42/Escpos/PrintBuffers/ImagePrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/ImagePrintBuffer.php
@@ -58,7 +58,7 @@ class ImagePrintBuffer implements PrintBuffer
         return $this -> printer;
     }
 
-    public function setPrinter(Printer $printer = null)
+    public function setPrinter(?Printer $printer = null)
     {
         $this -> printer = $printer;
     }

--- a/src/Mike42/Escpos/PrintBuffers/PrintBuffer.php
+++ b/src/Mike42/Escpos/PrintBuffers/PrintBuffer.php
@@ -48,7 +48,7 @@ interface PrintBuffer
      *
      * @param Printer|null $printer New printer
      */
-    public function setPrinter(Printer $printer = null);
+    public function setPrinter(?Printer $printer = null);
 
     /**
      * Accept UTF-8 text for printing.

--- a/src/Mike42/Escpos/Printer.php
+++ b/src/Mike42/Escpos/Printer.php
@@ -357,7 +357,7 @@ class Printer
      * @param CapabilityProfile|null $profile Supported features of this printer. If not set, the "default" CapabilityProfile will be used, which is suitable for Epson printers.
      * @throws InvalidArgumentException
      */
-    public function __construct(PrintConnector $connector, CapabilityProfile $profile = null)
+    public function __construct(PrintConnector $connector, ?CapabilityProfile $profile = null)
     {
         /* Set connector */
         $this -> connector = $connector;
@@ -882,7 +882,7 @@ class Printer
      * @param int|null $height The height of each line, in dots. If not set, the printer
      *  will reset to its default line spacing.
      */
-    public function setLineSpacing(int $height = null)
+    public function setLineSpacing(?int $height = null)
     {
         if ($height === null) {
             // Reset to default

--- a/test/unit/ImagickEscposImageTest.php
+++ b/test/unit/ImagickEscposImageTest.php
@@ -115,7 +115,7 @@ class ImagickEscposImageTest extends PHPUnit\Framework\TestCase
     /**
      * Same as above, loading document and checking pages against some expected values.
      */
-    private function loadAndCheckPdf($fn, $width, $height, array $rasterFormat = null, array $columnFormat = null)
+    private function loadAndCheckPdf($fn, $width, $height, ?array $rasterFormat = null, ?array $columnFormat = null)
     {
         if (!EscposImage::isImagickLoaded()) {
             $this -> markTestSkipped("imagick plugin required for this test");


### PR DESCRIPTION
Straight forward fix to avoid deprecation messages on newer PHP versions.